### PR TITLE
Pass tags onto autoscaling group

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,12 @@ module "website" {
 | <a name="input_internet_gateway_id"></a> [internet\_gateway\_id](#input\_internet\_gateway\_id) | AWS Internet Gateway must be present. Ensure by passing its id. | `string` | n/a | yes |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | SSH keypair name to be deployed in EC2 instances | `any` | n/a | yes |
 | <a name="input_max_instance_lifetime_days"></a> [max\_instance\_lifetime\_days](#input\_max\_instance\_lifetime\_days) | The maximum amount of time, in \_days\_, that an instance can be in service, values must be either equal to 0 or between 7 and 365 days. | `number` | `30` | no |
+| <a name="input_min_healthy_percentage"></a> [min\_healthy\_percentage](#input\_min\_healthy\_percentage) | Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `100` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Root volume size in EC2 instance in Gigabytes | `number` | `30` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Descriptive name of a service that will use this VPC | `string` | `"website"` | no |
 | <a name="input_stickiness_enabled"></a> [stickiness\_enabled](#input\_stickiness\_enabled) | If true, enable stickiness on the target group ensuring a clients is forwarded to the same target. | `bool` | `false` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnet ids where load balancer should be present | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to each resource | `map` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to instances in the autoscaling group. | `map` | <pre>{<br>  "Name": "webserver"<br>}</pre> | no |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | TCP port that a target listens to to serve requests from the load balancer. | `number` | `80` | no |
 | <a name="input_userdata"></a> [userdata](#input\_userdata) | userdata for cloud-init to provision EC2 instances | `any` | n/a | yes |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | How much time to wait until all instances are healthy | `string` | `"20m"` | no |
@@ -108,6 +109,8 @@ module "website" {
 
 | Name | Description |
 |------|-------------|
+| <a name="output_asg_arn"></a> [asg\_arn](#output\_asg\_arn) | ARN of the created autoscaling group |
+| <a name="output_asg_name"></a> [asg\_name](#output\_asg\_name) | Name of the created autoscaling group |
 | <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNA namae of the load balancer. |
 | <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | Target group ARN that listens to the service port. |
 | <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | Zone id where A records are created for the service. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,13 @@ output "target_group_arn" {
   description = "Target group ARN that listens to the service port."
   value       = aws_alb_target_group.website.arn
 }
+
+output "asg_arn" {
+  description = "ARN of the created autoscaling group"
+  value       = aws_autoscaling_group.website.arn
+}
+
+output "asg_name" {
+  description = "Name of the created autoscaling group"
+  value       = aws_autoscaling_group.website.name
+}

--- a/test_data/test_create_lb/main.tf
+++ b/test_data/test_create_lb/main.tf
@@ -16,4 +16,5 @@ module "lb" {
   userdata              = data.template_cloudinit_config.webserver_init.rendered
   health_check_type     = "ELB"
   webserver_permissions = data.aws_iam_policy_document.webserver_permissions.json
+  tags                  = var.tags
 }

--- a/test_data/test_create_lb/outputs.tf
+++ b/test_data/test_create_lb/outputs.tf
@@ -13,3 +13,7 @@ output "network_subnet_all_ids" {
 output "network_vpc_cidr_block" {
   value = module.network.vpc_cidr_block
 }
+
+output "asg_name" {
+  value = module.lb.asg_name
+}

--- a/test_data/test_create_lb/variables.tf
+++ b/test_data/test_create_lb/variables.tf
@@ -1,3 +1,4 @@
 variable "region" {}
 variable "dns_zone" {}
 variable "ubuntu_codename" {}
+variable "tags" {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,3 +58,8 @@ def route53_client(boto3_session):
 @pytest.fixture()
 def elbv2_client(boto3_session):
     return boto3_session.client("elbv2", region_name=REGION)
+
+
+@pytest.fixture()
+def autoscaling_client(boto3_session):
+    return boto3_session.client("autoscaling", region_name=REGION)

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "ami" {
   type        = string
 }
 
+variable "min_healthy_percentage" {
+  description = "Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group."
+  default     = 100
+}
+
 variable "asg_min_size" {
   description = "Minimum number of instances in ASG"
   type        = number
@@ -168,8 +173,10 @@ variable "stickiness_enabled" {
 }
 
 variable "tags" {
-  description = "Tags to apply to each resource"
-  default     = {}
+  description = "Tags to apply to instances in the autoscaling group."
+  default = {
+    Name : "webserver"
+  }
 }
 
 variable "target_group_port" {


### PR DESCRIPTION
Thare was the tags variable, butturns out, it was not used at all.
The same time users might need to customize tags passed onto instances
in the autosclaing group.
