### PR TITLE
Spearate min_size and min_elb_capacity in ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,13 +60,14 @@ locals {
     managed-by : "terraform"
     account : data.aws_caller_identity.current.account_id
   }
+  min_elb_capacity = var.asg_min_elb_capacity != null ? var.asg_min_elb_capacity : var.asg_min_size
 }
 
 resource "aws_autoscaling_group" "website" {
   name_prefix               = aws_launch_template.website.name_prefix
   min_size                  = var.asg_min_size
   max_size                  = var.asg_max_size
-  min_elb_capacity          = var.asg_min_size
+  min_elb_capacity          = local.min_elb_capacity
   vpc_zone_identifier       = var.backend_subnets
   health_check_type         = var.health_check_type
   wait_for_capacity_timeout = var.wait_for_capacity_timeout

--- a/tests/test_create_lb.py
+++ b/tests/test_create_lb.py
@@ -128,7 +128,12 @@ def test_lb(ec2_client, route53_client, elbv2_client, autoscaling_client):
             )
             current_refreshes = 0
             for refresh in response["InstanceRefreshes"]:
-                if refresh["Status"] in ["Pending", "InProgress", "Cancelling", "RollbackInProgress"]:
+                if refresh["Status"] in [
+                    "Pending",
+                    "InProgress",
+                    "Cancelling",
+                    "RollbackInProgress",
+                ]:
                     current_refreshes += 1
 
             if current_refreshes > 0:

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "min_healthy_percentage" {
   default     = 100
 }
 
+variable "asg_min_elb_capacity" {
+  description = "Terraform will wait until this many EC2 instances in the autoscaling group become healthy. By default, it's equal to var.asg_min_size."
+  type        = number
+  default     = null
+}
+
 variable "asg_min_size" {
   description = "Minimum number of instances in ASG"
   type        = number


### PR DESCRIPTION
Sometimes you don't need to wait until all min_size targets become
healthy.
Example, is ECS service when number of containers is twice less than
number of EC2 instances in the ASG.
