### PR TITLE
Fix dependency on certificate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,9 @@ resource "aws_lb_listener" "ssl" {
     type             = "forward"
     target_group_arn = aws_alb_target_group.website.arn
   }
+  depends_on = [
+    aws_acm_certificate_validation.website
+  ]
 }
 
 resource "aws_alb_target_group" "website" {

--- a/ssl.tf
+++ b/ssl.tf
@@ -4,6 +4,9 @@ resource "aws_acm_certificate" "website" {
   subject_alternative_names = [
     for record in var.dns_a_records : trimprefix(join(".", [record, data.aws_route53_zone.webserver_zone.name]), ".")
   ]
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "cert_validation" {

--- a/test_data/test_create_lb/client.tf
+++ b/test_data/test_create_lb/client.tf
@@ -3,4 +3,7 @@ resource "aws_instance" "client" {
   instance_type = "t3.micro"
   subnet_id     = module.network.subnet_public_ids[0]
   key_name      = aws_key_pair.test.key_name
+  tags = {
+    Name : "foo-app-client"
+  }
 }

--- a/test_data/test_create_lb/datasources.tf
+++ b/test_data/test_create_lb/datasources.tf
@@ -12,7 +12,8 @@ data "template_cloudinit_config" "webserver_init" {
           {
             "package_update" : true,
             packages : [
-              "xinetd"
+              "xinetd",
+              "net-tools"
             ]
             write_files : [
               {

--- a/test_data/test_create_lb/main.tf
+++ b/test_data/test_create_lb/main.tf
@@ -15,7 +15,7 @@ module "lb" {
   asg_min_size          = 3
   internet_gateway_id   = module.network.internet_gateway_id
   zone_id               = data.aws_route53_zone.website.zone_id
-  dns_a_records         = ["", "www", "bogus-test-stuff"]
+  dns_a_records         = var.dns_a_records
   key_pair_name         = aws_key_pair.test.key_name
   userdata              = data.template_cloudinit_config.webserver_init.rendered
   health_check_type     = "ELB"

--- a/test_data/test_create_lb/variables.tf
+++ b/test_data/test_create_lb/variables.tf
@@ -1,4 +1,7 @@
 variable "region" {}
+variable "dns_a_records" {
+  default = ["", "www", "bogus-test-stuff"]
+}
 variable "dns_zone" {}
 variable "ubuntu_codename" {}
 variable "tags" {}

--- a/tests/test_update_dns.py
+++ b/tests/test_update_dns.py
@@ -1,0 +1,72 @@
+from pprint import pformat
+from os import path as osp
+from textwrap import dedent
+from time import sleep
+
+import pytest
+import requests
+from infrahouse_toolkit.terraform import terraform_apply
+
+from tests.conftest import (
+    LOG,
+    TEST_ZONE,
+    REGION,
+    UBUNTU_CODENAME,
+    TRACE_TERRAFORM,
+    DESTROY_AFTER,
+)
+
+
+@pytest.mark.flaky(reruns=0, reruns_delay=30)
+@pytest.mark.timeout(1800)
+def test_update_dns(ec2_client, route53_client, elbv2_client, autoscaling_client):
+    terraform_dir = "test_data/test_create_lb"
+
+    instance_name = "foo-app"
+    with open(osp.join(terraform_dir, "terraform.tfvars"), "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                region = "{REGION}"
+                dns_zone = "{TEST_ZONE}"
+                ubuntu_codename = "{UBUNTU_CODENAME}"
+                tags = {{
+                    Name: "{instance_name}"
+                }}
+                """
+            )
+        )
+
+    # Create website pod first time
+    with terraform_apply(
+        terraform_dir,
+        destroy_after=DESTROY_AFTER,
+        json_output=True,
+        enable_trace=TRACE_TERRAFORM,
+    ) as tf_output:
+        assert len(tf_output["network_subnet_private_ids"]) == 3
+        assert len(tf_output["network_subnet_public_ids"]) == 3
+
+        # Update DNS records
+        with open(osp.join(terraform_dir, "terraform.tfvars"), "w") as fp:
+            fp.write(
+                dedent(
+                    f"""
+                        region = "{REGION}"
+                        dns_zone = "{TEST_ZONE}"
+                        ubuntu_codename = "{UBUNTU_CODENAME}"
+                        tags = {{
+                            Name: "{instance_name}"
+                        }}
+                        dns_a_records = ["", "www"]
+                        """
+                )
+            )
+        # Make sure the second apply succeeds
+        with terraform_apply(
+            terraform_dir,
+            destroy_after=DESTROY_AFTER,
+            json_output=True,
+            enable_trace=TRACE_TERRAFORM,
+        ):
+            assert True


### PR DESCRIPTION
The SSL listener is attached to a certificate. Or vice versa, you might
say. By default Terraform doesn't do a job of orchestrating changes
well. When you update DNS records, Terraform will have to re-create the
certificate, but it wants to delete the certificate first w/o removing
it from the listener. The delete operation fails. To solve this problem
the certificate resouce now has a lifecycle rule
`create_before_destroy`.

The second problem. The listener must be attached to a valid
certificate. When you just create the certificate, it takes time for AWS
to validate it. To ensure the certificate is valid, the SSL listener has
a dependency on `aws_acm_certificate_validation.website`.

The `tests/test_update_dns.py` test verifies the correct behavior
without failures.
