### PR TITLE
Add alb_healthcheck_enabled to enable/disable target group healthchecks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ resource "aws_alb_target_group" "website" {
   }
 
   health_check {
+    enabled             = var.alb_healthcheck_enabled
     path                = var.alb_healthcheck_path
     port                = var.alb_healthcheck_port
     protocol            = var.alb_healthcheck_protocol

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "alb_healthcheck_enabled" {
+  description = "Whether health checks are enabled."
+  type        = bool
+  default     = true
+}
 variable "alb_healthcheck_path" {
   description = "Path on the webserver that the elb will check to determine whether the instance is healthy or not"
   type        = string


### PR DESCRIPTION
You might want to disable the target group healthcheck if the ASG is
used for ECS.
