### PR TITLE
Allow any type value for alb_healthcheck_port

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "alb_healthcheck_path" {
 
 variable "alb_healthcheck_port" {
   description = "Port of the webserver that the elb will check to determine whether the instance is healthy or not"
-  type        = number
+  type        = any
   default     = 80
 }
 


### PR DESCRIPTION
The default value in the AWS provider for health_check.port is
"traffic-port" which is a string.
We want to provide the "traffic-port" as a value, so making it `type=any`.
