### PR TITLE
Use A alias again

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "website" {
     aws.dns = aws.aws-uw1
   }
   source                = "infrahouse/website-pod/aws"
-  version               = "~> 2.3"
+  version               = "~> 2.5"
   environment           = var.environment
   ami                   = data.aws_ami.ubuntu_22.image_id
   backend_subnets       = module.website-vpc.subnet_private_ids
@@ -69,11 +69,9 @@ module "website" {
 | [aws_autoscaling_policy.cpu_load](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_policy) | resource |
 | [aws_launch_template.website](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_lb_listener.ssl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_route53_record.apex](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.cert_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_network_interface.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_interface) | data source |
 | [aws_route53_zone.webserver_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
@@ -127,7 +125,6 @@ module "website" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_alb_public_ips"></a> [alb\_public\_ips](#output\_alb\_public\_ips) | List of public IPv4 addresses assigned to the load balancer. |
 | <a name="output_asg_arn"></a> [asg\_arn](#output\_asg\_arn) | ARN of the created autoscaling group |
 | <a name="output_asg_name"></a> [asg\_name](#output\_asg\_name) | Name of the created autoscaling group |
 | <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNA namae of the load balancer. |

--- a/datasources.tf
+++ b/datasources.tf
@@ -8,22 +8,3 @@ data "aws_route53_zone" "webserver_zone" {
   provider = aws.dns
   zone_id  = var.zone_id
 }
-
-# Public IP Addresses on the ALB
-data "aws_network_interface" "alb" {
-  count = length(var.subnets)
-
-  filter {
-    name   = "description"
-    values = ["ELB ${aws_alb.website.arn_suffix}"]
-  }
-
-  filter {
-    name   = "subnet-id"
-    values = [var.subnets[count.index]]
-  }
-  depends_on = [
-    aws_alb.website,
-    aws_autoscaling_group.website
-  ]
-}

--- a/dns.tf
+++ b/dns.tf
@@ -1,25 +1,12 @@
-locals {
-  cname_list = [for r in var.dns_a_records : r if r != ""]
-  a_list     = [for subnet in data.aws_network_interface.alb : subnet["association"][0]["public_ip"]]
-}
 resource "aws_route53_record" "extra" {
-  count    = length(local.cname_list)
   provider = aws.dns
+  count    = length(var.dns_a_records)
   zone_id  = var.zone_id
-  name     = join(".", [local.cname_list[count.index], data.aws_route53_zone.webserver_zone.name])
-  type     = "CNAME"
-  ttl      = 300
-  records = [
-    aws_alb.website.dns_name
-  ]
-}
-
-resource "aws_route53_record" "apex" {
-  count    = contains(var.dns_a_records, "") ? 1 : 0
-  provider = aws.dns
-  zone_id  = var.zone_id
-  name     = data.aws_route53_zone.webserver_zone.name
+  name     = trimprefix(join(".", [var.dns_a_records[count.index], data.aws_route53_zone.webserver_zone.name]), ".")
   type     = "A"
-  ttl      = 300
-  records  = local.a_list
+  alias {
+    name                   = aws_alb.website.dns_name
+    zone_id                = aws_alb.website.zone_id
+    evaluate_target_health = true
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,8 +22,3 @@ output "asg_name" {
   description = "Name of the created autoscaling group"
   value       = aws_autoscaling_group.website.name
 }
-
-output "alb_public_ips" {
-  description = "List of public IPv4 addresses assigned to the load balancer."
-  value       = local.a_list
-}

--- a/test_data/test_create_lb/outputs.tf
+++ b/test_data/test_create_lb/outputs.tf
@@ -17,6 +17,3 @@ output "network_vpc_cidr_block" {
 output "asg_name" {
   value = module.lb.asg_name
 }
-output "alb_private_ips" {
-  value = module.lb.alb_public_ips
-}


### PR DESCRIPTION
In the version 2.* I added support of a custom AWS provider for DNS
changes. It was needed if a zone was hosted in a separare AWS account or
required specific provider configuration.

That change made me rework the DNS part of the module. I mistakenly
assumed the module can't use Amazon alias feature anymore. So, I changed
how DNS records were created. The apex A record (foo.com) was created
using public IP addresses on the load balancer. The module got them from
a data source `aws_network_interface`. That method has two critical
flaws.

- Even when the load balancer is created the network interfaces don't
immediately show up in the data source, so it causes apply failures.
- The network interfaces change! I saw somewhere in docs or forums that
once created, the load balancer nodes do not change. Well, maybe it's
true for NLBs, but not for ALBs (proven by a downtime).

The same time, I realised that my assumption about impossibility of using
Amazon's A record alias was wrong. So I tested and proved it can be
done.

This PR brings back the old proven way of creating the DNS records as it
was done in the 1.* versions.
