### PR TITLE
Don't create a backend_healthcheck if alb_healthcheck_port == "traffic-port"

### DIFF
--- a/security_group_backend.tf
+++ b/security_group_backend.tf
@@ -46,7 +46,7 @@ resource "aws_vpc_security_group_ingress_rule" "backend_user_traffic" {
 
 resource "aws_vpc_security_group_ingress_rule" "backend_healthcheck" {
   # Add the rule only if the healthcheck port is different from the traffic port
-  count             = var.alb_healthcheck_port != var.target_group_port ? 1 : 0
+  count             = var.alb_healthcheck_port == var.target_group_port || var.alb_healthcheck_port == "traffic-port" ? 0 : 1
   description       = "Health checks from the Load Balancer"
   security_group_id = aws_security_group.backend.id
   from_port         = var.alb_healthcheck_port


### PR DESCRIPTION
When alb_healthcheck_port == "traffic-port", then we don't need the
health check rule in the security group.
