### PR TITLE
Fix hardcoded root device name

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -12,3 +12,12 @@ data "aws_route53_zone" "webserver_zone" {
 data "aws_vpc" "service" {
   id = data.aws_subnet.selected.vpc_id
 }
+
+data "aws_ami" "selected" {
+  filter {
+    name = "image-id"
+    values = [
+      var.ami
+    ]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "aws_launch_template" "website" {
   }
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = data.aws_ami.selected.root_device_name
     ebs {
       volume_size           = var.root_volume_size
       delete_on_termination = true


### PR DESCRIPTION
Well, old hardcoded value was plain wrong on modern instance type. As a
result, an instance ended up with a default root volume (8G typically)
and a big unformatted volume. Fixing it by reading the root device name
from AMI.
