### PR TITLE
Add new variable asg_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ They will be added to the backend instance alongside with the created backend se
 | [aws_vpc_security_group_ingress_rule.backend_ssh_local](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.backend_user_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_ami.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_route53_zone.webserver_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -128,6 +129,7 @@ They will be added to the backend instance alongside with the created backend se
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG | `number` | `10` | no |
 | <a name="input_asg_min_elb_capacity"></a> [asg\_min\_elb\_capacity](#input\_asg\_min\_elb\_capacity) | Terraform will wait until this many EC2 instances in the autoscaling group become healthy. By default, it's equal to var.asg\_min\_size. | `number` | `null` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of instances in ASG | `number` | `2` | no |
+| <a name="input_asg_name"></a> [asg\_name](#input\_asg\_name) | Autoscaling group name, if provided. | `string` | `null` | no |
 | <a name="input_asg_scale_in_protected_instances"></a> [asg\_scale\_in\_protected\_instances](#input\_asg\_scale\_in\_protected\_instances) | Behavior when encountering instances protected from scale in are found. Available behaviors are Refresh, Ignore, and Wait. | `string` | `"Ignore"` | no |
 | <a name="input_attach_tagret_group_to_asg"></a> [attach\_tagret\_group\_to\_asg](#input\_attach\_tagret\_group\_to\_asg) | By default we want to register all ASG instances in the target group. However ECS registers targets itself. Disable it if using website-pod for ECS. | `bool` | `true` | no |
 | <a name="input_autoscaling_target_cpu_load"></a> [autoscaling\_target\_cpu\_load](#input\_autoscaling\_target\_cpu\_load) | Target CPU load for autoscaling | `number` | `60` | no |

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,8 @@ locals {
 }
 
 resource "aws_autoscaling_group" "website" {
-  name_prefix               = aws_launch_template.website.name_prefix
+  name                      = var.asg_name
+  name_prefix               = var.asg_name == null ? aws_launch_template.website.name_prefix : null
   min_size                  = var.asg_min_size
   max_size                  = var.asg_max_size
   min_elb_capacity          = local.min_elb_capacity
@@ -117,7 +118,8 @@ resource "aws_autoscaling_group" "website" {
 }
 
 resource "aws_launch_template" "website" {
-  name_prefix   = var.alb_name_prefix
+  name          = var.asg_name
+  name_prefix   = var.asg_name == null ? var.alb_name_prefix : null
   image_id      = var.ami
   instance_type = var.instance_type
   user_data     = var.userdata

--- a/test_data/test_create_lb/datasources.tf
+++ b/test_data/test_create_lb/datasources.tf
@@ -1,4 +1,4 @@
-data "template_cloudinit_config" "webserver_init" {
+data "cloudinit_config" "webserver_init" {
   gzip          = false
   base64_encode = true
 

--- a/test_data/test_create_lb/main.tf
+++ b/test_data/test_create_lb/main.tf
@@ -12,12 +12,13 @@ module "lb" {
   subnets               = module.network.subnet_public_ids
   ami                   = data.aws_ami.ubuntu.id
   backend_subnets       = module.network.subnet_private_ids
+  asg_name              = var.asg_name
   asg_min_size          = 3
   internet_gateway_id   = module.network.internet_gateway_id
   zone_id               = data.aws_route53_zone.website.zone_id
   dns_a_records         = var.dns_a_records
   key_pair_name         = aws_key_pair.test.key_name
-  userdata              = data.template_cloudinit_config.webserver_init.rendered
+  userdata              = data.cloudinit_config.webserver_init.rendered
   health_check_type     = "ELB"
   webserver_permissions = data.aws_iam_policy_document.webserver_permissions.json
   tags                  = var.tags

--- a/test_data/test_create_lb/network.tf
+++ b/test_data/test_create_lb/network.tf
@@ -1,6 +1,6 @@
 module "network" {
   source  = "infrahouse/service-network/aws"
-  version = "~> 2.0"
+  version = "~> 2.3"
 
   environment           = "dev"
   service_name          = "test_data/terraform-aws-website-pod"

--- a/test_data/test_create_lb/terraform.tf
+++ b/test_data/test_create_lb/terraform.tf
@@ -4,10 +4,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.11"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2"
-
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.3"
     }
   }
 }

--- a/test_data/test_create_lb/variables.tf
+++ b/test_data/test_create_lb/variables.tf
@@ -5,3 +5,4 @@ variable "dns_a_records" {
 variable "dns_zone" {}
 variable "ubuntu_codename" {}
 variable "tags" {}
+variable "asg_name" { default = null }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_ACCOUNT = "303467602807"
 TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/website-pod-tester"
 DEFAULT_PROGRESS_INTERVAL = 10
 TRACE_TERRAFORM = False
-DESTROY_AFTER = True
+DESTROY_AFTER = False
 UBUNTU_CODENAME = "jammy"
 
 LOG = logging.getLogger(__name__)

--- a/tests/test_asg_name.py
+++ b/tests/test_asg_name.py
@@ -1,0 +1,47 @@
+from pprint import pformat
+from os import path as osp
+from textwrap import dedent
+from time import sleep
+
+import pytest
+import requests
+from infrahouse_toolkit.terraform import terraform_apply
+
+from tests.conftest import (
+    LOG,
+    TEST_ZONE,
+    REGION,
+    UBUNTU_CODENAME,
+    TRACE_TERRAFORM,
+    DESTROY_AFTER,
+)
+
+
+@pytest.mark.flaky(reruns=0, reruns_delay=30)
+@pytest.mark.timeout(1800)
+def test_lb(ec2_client, route53_client, elbv2_client, autoscaling_client):
+    terraform_dir = "test_data/test_create_lb"
+
+    instance_name = "foo-app"
+    with open(osp.join(terraform_dir, "terraform.tfvars"), "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                region = "{REGION}"
+                dns_zone = "{TEST_ZONE}"
+                ubuntu_codename = "{UBUNTU_CODENAME}"
+                asg_name = "foo-asg"
+                tags = {{
+                    Name: "{instance_name}"
+                }}
+                """
+            )
+        )
+
+    with terraform_apply(
+        terraform_dir,
+        destroy_after=DESTROY_AFTER,
+        json_output=True,
+        enable_trace=TRACE_TERRAFORM,
+    ) as tf_output:
+        assert tf_output["asg_name"]["value"] == "foo-asg"

--- a/tests/test_create_lb.py
+++ b/tests/test_create_lb.py
@@ -193,9 +193,10 @@ def test_lb(ec2_client, route53_client, elbv2_client, autoscaling_client):
             tags["Name"] == instance_name
         ), f"Instance's name should be set to {instance_name}."
 
-    response = ec2_client.describe_volumes(
-        Filters=[{"Name": "status", "Values": ["available"]}],
-    )
-    assert (
-        len(response["Volumes"]) == 0
-    ), "Unexpected number of EBS volumes: %s" % pformat(response, indent=4)
+    if DESTROY_AFTER:
+        response = ec2_client.describe_volumes(
+            Filters=[{"Name": "status", "Values": ["available"]}],
+        )
+        assert (
+            len(response["Volumes"]) == 0
+        ), "Unexpected number of EBS volumes: %s" % pformat(response, indent=4)

--- a/variables.tf
+++ b/variables.tf
@@ -103,6 +103,12 @@ variable "asg_max_size" {
   default     = 10
 }
 
+variable "asg_name" {
+  description = "Autoscaling group name, if provided."
+  type        = string
+  default     = null
+}
+
 variable "asg_scale_in_protected_instances" {
   description = "Behavior when encountering instances protected from scale in are found. Available behaviors are Refresh, Ignore, and Wait."
   type        = string


### PR DESCRIPTION
In some cases a user needs to provide a fixed autoscaling group name. The asg_name variable will be used as a launch_template name and the ASG name will use the launchtemaplate attribute name. That way the module preserves ASG dependency on the launch template (needed for zero-downtime migrations) and provides the user with ability to set the ASG name.
