### PR TITLE
Upgrade instance-profile module to 1.4.1

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -6,7 +6,7 @@ resource "random_string" "profile_suffix" {
 
 module "instance_profile" {
   source       = "registry.infrahouse.com/infrahouse/instance-profile/aws"
-  version      = "1.4.0"
+  version      = "1.4.1"
   profile_name = "${var.service_name}-instance-${random_string.profile_suffix.result}"
   role_name    = var.instance_role_name
   permissions  = var.instance_profile_permissions == null ? data.aws_iam_policy_document.default_permissions.json : var.instance_profile_permissions


### PR DESCRIPTION
instance-profile 1.4.1 fixes a problem with too long profile/role name/name prefix