### PR TITLE
Sync tag rules with tcp-pod module

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -48,8 +48,6 @@ resource "aws_autoscaling_group" "website" {
   dynamic "tag" {
     for_each = merge(
       local.default_asg_tags,
-      var.tags,
-      data.aws_default_tags.provider.tags
     )
     content {
       key                 = tag.key

--- a/locals.tf
+++ b/locals.tf
@@ -10,14 +10,18 @@ locals {
     var.upstream_module != null ? {
       upstream_module : var.upstream_module
     } : {},
-    local.vanta_tags
+    local.vanta_tags,
+    var.tags
   )
+
   default_asg_tags = merge(
     {
-      Name : "webserver"
+      Name : var.service_name
     },
-    local.default_module_tags
+    local.default_module_tags,
+    data.aws_default_tags.provider.tags,
   )
+
   vanta_tags = merge(
     var.vanta_owner != null ? {
       VantaOwner : var.vanta_owner
@@ -37,6 +41,7 @@ locals {
       VantaNoAlert : var.vanta_no_alert
     } : {}
   )
+
   min_elb_capacity = var.asg_min_elb_capacity != null ? var.asg_min_elb_capacity : var.asg_min_size
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
   elb_account_map = {

--- a/main.tf
+++ b/main.tf
@@ -20,8 +20,7 @@ resource "aws_alb" "website" {
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false
-    },
-    var.tags,
+    }
   )
 }
 
@@ -43,6 +42,13 @@ resource "aws_alb_listener" "redirect_to_ssl" {
       status_code = "HTTP_301"
     }
   }
+  tags = merge(
+    local.default_module_tags,
+    {
+      VantaContainsUserData : false
+      VantaContainsEPHI : false
+    }
+  )
 }
 
 resource "aws_lb_listener" "ssl" {

--- a/security_group_alb.tf
+++ b/security_group_alb.tf
@@ -4,10 +4,10 @@ resource "aws_security_group" "alb" {
   vpc_id      = data.aws_subnet.selected.vpc_id
 
   tags = merge(
+    local.default_module_tags,
     {
       Name : "${var.service_name} load balancer"
     },
-    local.default_module_tags
   )
 }
 
@@ -19,10 +19,10 @@ resource "aws_vpc_security_group_ingress_rule" "alb_listener_port" {
   ip_protocol       = "tcp"
   cidr_ipv4         = "0.0.0.0/0"
   tags = merge(
+    local.default_module_tags,
     {
       Name = "user traffic"
     },
-    local.default_module_tags,
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false
@@ -38,10 +38,10 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
   ip_protocol       = "tcp"
   cidr_ipv4         = "0.0.0.0/0"
   tags = merge(
+    local.default_module_tags,
     {
       Name = "https user traffic"
     },
-    local.default_module_tags,
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false
@@ -57,10 +57,11 @@ resource "aws_vpc_security_group_ingress_rule" "alb_icmp" {
   ip_protocol       = "icmp"
   cidr_ipv4         = "0.0.0.0/0"
   tags = merge(
+    local.default_module_tags,
     {
       Name = "ICMP traffic"
     },
-    local.default_module_tags,
+
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false
@@ -74,10 +75,10 @@ resource "aws_vpc_security_group_egress_rule" "alb_outgoing" {
   ip_protocol       = "-1"
   cidr_ipv4         = "0.0.0.0/0"
   tags = merge(
+    local.default_module_tags,
     {
       Name = "outgoing traffic"
     },
-    local.default_module_tags,
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false

--- a/security_group_backend.tf
+++ b/security_group_backend.tf
@@ -69,10 +69,10 @@ resource "aws_vpc_security_group_ingress_rule" "backend_healthcheck" {
   ip_protocol       = "tcp"
   cidr_ipv4         = data.aws_vpc.service.cidr_block
   tags = merge(
+    local.default_module_tags,
     {
       Name = "healthcheck"
     },
-    local.default_module_tags,
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false
@@ -88,10 +88,10 @@ resource "aws_vpc_security_group_ingress_rule" "backend_icmp" {
   ip_protocol       = "icmp"
   cidr_ipv4         = "0.0.0.0/0"
   tags = merge(
+    local.default_module_tags,
     {
       Name = "ICMP traffic"
     },
-    local.default_module_tags,
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false
@@ -105,10 +105,10 @@ resource "aws_vpc_security_group_egress_rule" "backend_outgoing" {
   ip_protocol       = "-1"
   cidr_ipv4         = "0.0.0.0/0"
   tags = merge(
+    local.default_module_tags,
     {
       Name = "outgoing traffic"
     },
-    local.default_module_tags,
     {
       VantaContainsUserData : false
       VantaContainsEPHI : false

--- a/variables.tf
+++ b/variables.tf
@@ -291,11 +291,9 @@ variable "stickiness_enabled" {
 }
 
 variable "tags" {
-  description = "Tags to apply to instances in the autoscaling group."
+  description = "Tags to apply to resources creatded by the module."
   type        = map(string)
-  default = {
-    Name : "webserver"
-  }
+  default     = {}
 }
 
 variable "target_group_port" {


### PR DESCRIPTION
* Make tags more or less the same as in tcp-pod
* Ensure Tags like Name are properly overwritten. We need a module
  specific value, not one from default_module_tags.
