### PR TITLE
Use ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06 SSL policy

### DIFF
--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -33,6 +33,7 @@ jobs:
           role-to-assume: ${{ env.ROLE_ARN }}
           role-session-name: "terraform-ci"
           aws-region: "us-west-1"
+          role-duration-seconds: 7200
 
       # Install the latest version of Terraform CLI
       - name: Setup Terraform

--- a/main.tf
+++ b/main.tf
@@ -55,8 +55,9 @@ resource "aws_lb_listener" "ssl" {
   load_balancer_arn = aws_alb.website.arn
   port              = 443
   protocol          = "HTTPS"
-  ssl_policy        = ""
-  certificate_arn   = aws_acm_certificate.website.arn
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html
+  ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
+  certificate_arn = aws_acm_certificate.website.arn
   default_action {
     type = "fixed-response"
     fixed_response {


### PR DESCRIPTION
Using this policy because
* TLS 1.2+
* Doesn't include AES256-SHA