### PR TITLE
Add variable asg_lifecycle_hook_initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ be spot instances.
 | <a name="input_alb_name_prefix"></a> [alb\_name\_prefix](#input\_alb\_name\_prefix) | Name prefix for the load balancer | `string` | `"web"` | no |
 | <a name="input_ami"></a> [ami](#input\_ami) | Image for EC2 instances | `string` | n/a | yes |
 | <a name="input_asg_lifecycle_hook_heartbeat_timeout"></a> [asg\_lifecycle\_hook\_heartbeat\_timeout](#input\_asg\_lifecycle\_hook\_heartbeat\_timeout) | How much time in seconds to wait until the hook is completed before proceeding with the default action. | `number` | `3600` | no |
-| <a name="input_asg_lifecycle_hook_launching"></a> [asg\_lifecycle\_hook\_launching](#input\_asg\_lifecycle\_hook\_launching) | Create a LAUNCHING lifecycle hook, if True. | `bool` | `false` | no |
-| <a name="input_asg_lifecycle_hook_terminating"></a> [asg\_lifecycle\_hook\_terminating](#input\_asg\_lifecycle\_hook\_terminating) | Create a TERMINATING lifecycle hook, if True. | `bool` | `false` | no |
+| <a name="input_asg_lifecycle_hook_initial"></a> [asg\_lifecycle\_hook\_initial](#input\_asg\_lifecycle\_hook\_initial) | Create a LAUNCHING initial lifecycle hook with this name. | `string` | `null` | no |
+| <a name="input_asg_lifecycle_hook_launching"></a> [asg\_lifecycle\_hook\_launching](#input\_asg\_lifecycle\_hook\_launching) | Create a LAUNCHING lifecycle hook with this name. | `string` | `null` | no |
+| <a name="input_asg_lifecycle_hook_terminating"></a> [asg\_lifecycle\_hook\_terminating](#input\_asg\_lifecycle\_hook\_terminating) | Create a TERMINATING lifecycle hook with this name. | `string` | `null` | no |
 | <a name="input_asg_max_healthy_percentage"></a> [asg\_max\_healthy\_percentage](#input\_asg\_max\_healthy\_percentage) | Specifies the upper limit on the number of instances that are in the InService or Pending state with a healthy status during an instance replacement activity. | `number` | `200` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG | `number` | `10` | no |
 | <a name="input_asg_min_elb_capacity"></a> [asg\_min\_elb\_capacity](#input\_asg\_min\_elb\_capacity) | Terraform will wait until this many EC2 instances in the autoscaling group become healthy. By default, it's equal to var.asg\_min\_size. | `number` | `null` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -41,6 +41,14 @@ resource "aws_autoscaling_group" "website" {
       }
     }
   }
+  dynamic "initial_lifecycle_hook" {
+    for_each = var.asg_lifecycle_hook_initial != null ? [1] : []
+    content {
+      lifecycle_transition = "autoscaling:EC2_INSTANCE_LAUNCHING"
+      name                 = var.asg_lifecycle_hook_initial
+      heartbeat_timeout    = var.asg_lifecycle_hook_heartbeat_timeout
+    }
+  }
   instance_maintenance_policy {
     min_healthy_percentage = var.asg_min_healthy_percentage
     max_healthy_percentage = var.asg_max_healthy_percentage
@@ -114,16 +122,16 @@ resource "aws_launch_template" "website" {
 }
 
 resource "aws_autoscaling_lifecycle_hook" "launching" {
-  count                  = var.asg_lifecycle_hook_launching == true ? 1 : 0
-  name                   = "launching"
+  count                  = var.asg_lifecycle_hook_launching != null ? 1 : 0
+  name                   = var.asg_lifecycle_hook_launching
   heartbeat_timeout      = var.asg_lifecycle_hook_heartbeat_timeout
   autoscaling_group_name = aws_autoscaling_group.website.name
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
 }
 
 resource "aws_autoscaling_lifecycle_hook" "terminating" {
-  count                  = var.asg_lifecycle_hook_terminating == true ? 1 : 0
-  name                   = "terminating"
+  count                  = var.asg_lifecycle_hook_terminating != null ? 1 : 0
+  name                   = var.asg_lifecycle_hook_terminating
   heartbeat_timeout      = var.asg_lifecycle_hook_heartbeat_timeout
   autoscaling_group_name = aws_autoscaling_group.website.name
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"

--- a/variables.tf
+++ b/variables.tf
@@ -97,16 +97,22 @@ variable "min_healthy_percentage" {
   default     = 100
 }
 
+variable "asg_lifecycle_hook_initial" {
+  description = "Create a LAUNCHING initial lifecycle hook with this name."
+  type        = string
+  default     = null
+}
+
 variable "asg_lifecycle_hook_launching" {
-  description = "Create a LAUNCHING lifecycle hook, if True."
-  type        = bool
-  default     = false
+  description = "Create a LAUNCHING lifecycle hook with this name."
+  type        = string
+  default     = null
 }
 
 variable "asg_lifecycle_hook_terminating" {
-  description = "Create a TERMINATING lifecycle hook, if True."
-  type        = bool
-  default     = false
+  description = "Create a TERMINATING lifecycle hook with this name."
+  type        = string
+  default     = null
 }
 
 variable "asg_lifecycle_hook_heartbeat_timeout" {


### PR DESCRIPTION
Behavior of asg_lifecycle_hook_terminating, asg_lifecycle_hook_launching changes.
It used to be a boolean variable. Now, it's a null-able string. If a value is given, the hook will be created.
