### PR TITLE
Add 2xRAM to root volume for swap

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -93,7 +93,8 @@ resource "aws_launch_template" "website" {
   block_device_mappings {
     device_name = data.aws_ami.selected.root_device_name
     ebs {
-      volume_size           = var.root_volume_size
+      # 2 * RAM size is reserved for swap
+      volume_size           = var.root_volume_size + 2 * data.aws_ec2_instance_type.selected.memory_size / 1024
       delete_on_termination = true
     }
   }

--- a/datasources.tf
+++ b/datasources.tf
@@ -24,6 +24,10 @@ data "aws_ami" "selected" {
   }
 }
 
+data "aws_ec2_instance_type" "selected" {
+  instance_type = var.instance_type
+}
+
 data "aws_iam_policy_document" "default_permissions" {
   statement {
     actions = [


### PR DESCRIPTION
Puppet base profile allocates 2*RAM swap on the root volume. Thus,
the default 30G volume isn't enough if the instance type has even 16G of
RAM.
