### PR TITLE
Keep module_version on load balancer

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,7 +7,6 @@ locals {
       service : var.service_name
       account : data.aws_caller_identity.current.account_id
       created_by_module : local.module
-      module_version : local.module_version
     },
     var.upstream_module != null ? {
       upstream_module : var.upstream_module

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,10 @@ resource "aws_alb" "website" {
     local.default_module_tags,
     local.access_log_tags,
     {
+      module_version : local.module_version
+    },
+
+    {
       VantaContainsUserData : false
       VantaContainsEPHI : false
     }


### PR DESCRIPTION
`module_version` on every resource made module version upgrade too
noisy. Every resource had at least one change which was tags.
The PR don't add the `module_version` tag except the "main" resource
which is a load balancer for this module.
