### PR TITLE
feat: add AWS provider version 6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ for line in sys.stdin:
 endef
 export PRINT_HELP_PYSCRIPT
 
+TEST_REGION="us-west-2"
+TEST_ROLE="arn:aws:iam::303467602807:role/website-pod-tester"
+
 help: install-hooks
 	@python -c "$$PRINT_HELP_PYSCRIPT" < Makefile
 
@@ -26,11 +29,28 @@ install-hooks:  ## Install repo hooks
 test:  ## Run tests on the module
 	pytest -xvvs tests/
 
+.PHONY: test-keep
+test-keep:  ## Run a test and keep resources
+	pytest -xvvs \
+		--aws-region=${TEST_REGION} \
+		--test-role-arn=${TEST_ROLE} \
+		--keep-after \
+		-k  "internet-facing and aws-6" \
+		tests/test_create_lb.py
+
+.PHONY: test-clean
+test-clean:  ## Run a test and destroy resources
+	pytest -xvvs \
+		--aws-region=${TEST_REGION} \
+		--test-role-arn=${TEST_ROLE} \
+		-k  "internet-facing and aws-6" \
+		tests/test_create_lb.py
+
 
 .PHONY: bootstrap
 bootstrap: ## bootstrap the development environment
-	pip install -U "pip ~= 23.1"
-	pip install -U "setuptools ~= 68.0"
+	pip install -U "pip ~= 25.2"
+	pip install -U "setuptools ~= 80.9"
 	pip install -r requirements.txt
 
 .PHONY: clean

--- a/dns.tf
+++ b/dns.tf
@@ -20,8 +20,5 @@ resource "aws_route53_record" "extra_caa_amazon" {
   ttl      = 300
   records = [
     "0 issue \"amazon.com\"",
-    "0 issue \"amazontrust.com\"",
-    "0 issue \"awstrust.com\"",
-    "0 issue \"amazonaws.com\""
   ]
 }

--- a/iam.tf
+++ b/iam.tf
@@ -6,7 +6,7 @@ resource "random_string" "profile_suffix" {
 
 module "instance_profile" {
   source          = "registry.infrahouse.com/infrahouse/instance-profile/aws"
-  version         = "1.8.1"
+  version         = "1.9.0"
   profile_name    = "${var.service_name}-instance-${random_string.profile_suffix.result}"
   role_name       = var.instance_role_name
   permissions     = var.instance_profile_permissions == null ? data.aws_iam_policy_document.default_permissions.json : var.instance_profile_permissions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-black ~=25.1
-boto3 ~= 1.26
-infrahouse-core ~=  0.17.1
-infrahouse-toolkit ~= 2.0
-myst-parser ~=4.0
-pytest ~= 8.3
-pytest-infrahouse ~= 0.6
+infrahouse-core ~=  0.17
+pytest-infrahouse ~= 0.11
 pytest-timeout ~= 2.1
-pytest-rerunfailures ~=15.1
-requests ~= 2.32

--- a/ssl.tf
+++ b/ssl.tf
@@ -14,6 +14,9 @@ resource "aws_acm_certificate" "website" {
       VantaContainsEPHI : false
     }
   )
+  depends_on = [
+    aws_route53_record.extra_caa_amazon
+  ]
 }
 
 resource "aws_route53_record" "cert_validation" {
@@ -38,5 +41,8 @@ resource "aws_acm_certificate_validation" "website" {
   certificate_arn = aws_acm_certificate.website.arn
   validation_record_fqdns = [
     for d in aws_route53_record.cert_validation : d.fqdn
+  ]
+  depends_on = [
+    aws_route53_record.extra_caa_amazon
   ]
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11"
+      version = ">= 5.11, < 7.0"
       configuration_aliases = [
         aws.dns # AWS provider for DNS
       ]

--- a/test_data/.gitignore
+++ b/test_data/.gitignore
@@ -1,0 +1,1 @@
+terraform.tf

--- a/test_data/test_create_lb/datasources.tf
+++ b/test_data/test_create_lb/datasources.tf
@@ -42,7 +42,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-${var.ubuntu_codename}-*"]
+    values = [local.ami_name_pattern_pro]
   }
 
   filter {

--- a/test_data/test_create_lb/locals.tf
+++ b/test_data/test_create_lb/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  ami_name_pattern_pro = "ubuntu-pro-server/images/hvm-ssd-gp3/ubuntu-${var.ubuntu_codename}-*"
+}

--- a/test_data/test_create_lb/terraform.tf
+++ b/test_data/test_create_lb/terraform.tf
@@ -1,12 +1,9 @@
+
 terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11"
-    }
-    cloudinit = {
-      source  = "hashicorp/cloudinit"
-      version = "~> 2.3"
+      version = "~> 6.0"
     }
   }
 }

--- a/test_data/test_spot/terraform.tf
+++ b/test_data/test_spot/terraform.tf
@@ -2,11 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11"
-    }
-    cloudinit = {
-      source  = "hashicorp/cloudinit"
-      version = "~> 2.3"
+      version = "~> 6.0"
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,47 +1,18 @@
 from pprint import pformat
-from textwrap import dedent
 from time import sleep
 
-import pytest
 import logging
-from os import path as osp
 
 from infrahouse_core.logging import setup_logging
-from infrahouse_toolkit.terraform import terraform_apply
 
 DEFAULT_PROGRESS_INTERVAL = 10
 TEST_TIMEOUT = 3600
-TRACE_TERRAFORM = False
-UBUNTU_CODENAME = "jammy"
+UBUNTU_CODENAME = "noble"
 
-LOG = logging.getLogger(__name__)
-TEST_ZONE = "ci-cd.infrahouse.com"
+LOG = logging.getLogger()
 TERRAFORM_ROOT_DIR = "test_data"
 
 setup_logging(LOG, debug=True)
-
-
-@pytest.fixture(scope="session")
-def instance_profile(keep_after, test_role_arn, aws_region):
-    terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "instance_profile")
-
-    with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
-        fp.write(
-            dedent(
-                f"""
-                region   = "{aws_region}"
-                role_arn = "{test_role_arn}"
-                """
-            )
-        )
-
-    with terraform_apply(
-        terraform_module_dir,
-        destroy_after=not keep_after,
-        json_output=True,
-        enable_trace=TRACE_TERRAFORM,
-    ) as tf_output:
-        yield tf_output
 
 
 def wait_for_instance_refresh(asg_name, autoscaling_client):

--- a/tests/test_asg_name.py
+++ b/tests/test_asg_name.py
@@ -3,12 +3,10 @@ from os import path as osp
 from textwrap import dedent
 
 import pytest
-from infrahouse_toolkit.terraform import terraform_apply
+from pytest_infrahouse import terraform_apply
 
 from tests.conftest import (
-    TEST_ZONE,
     UBUNTU_CODENAME,
-    TRACE_TERRAFORM,
     TEST_TIMEOUT,
 )
 
@@ -18,6 +16,7 @@ def test_lb(
     service_network,
     keep_after,
     aws_region,
+    test_zone_name,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -31,7 +30,7 @@ def test_lb(
             dedent(
                 f"""
                 region          = "{aws_region}"
-                dns_zone        = "{TEST_ZONE}"
+                dns_zone        = "{test_zone_name}"
                 ubuntu_codename = "{UBUNTU_CODENAME}"
                 asg_name        = "foo-asg"
                 tags = {{
@@ -49,6 +48,5 @@ def test_lb(
         terraform_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         assert tf_output["asg_name"]["value"] == "foo-asg"

--- a/tests/test_instance_profile.py
+++ b/tests/test_instance_profile.py
@@ -4,13 +4,11 @@ from pprint import pformat
 from textwrap import dedent
 
 import pytest
-from infrahouse_toolkit.terraform import terraform_apply
+from pytest_infrahouse import terraform_apply
 
 from tests.conftest import (
     LOG,
-    TEST_ZONE,
     UBUNTU_CODENAME,
-    TRACE_TERRAFORM,
     TERRAFORM_ROOT_DIR,
     TEST_TIMEOUT,
     wait_for_instance_refresh,
@@ -24,6 +22,7 @@ def test_lb(
     iam_client,
     keep_after,
     aws_region,
+    test_zone_name,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -35,7 +34,7 @@ def test_lb(
             dedent(
                 f"""
                 region                = "{aws_region}"
-                dns_zone              = "{TEST_ZONE}"
+                dns_zone              = "{test_zone_name}"
                 ubuntu_codename       = "{UBUNTU_CODENAME}"
                 tags = {{
                     Name: "foo-app"
@@ -53,7 +52,6 @@ def test_lb(
         terraform_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         asg_name = tf_output["asg_name"]["value"]
         wait_for_instance_refresh(asg_name, autoscaling_client)

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -4,12 +4,10 @@ from pprint import pformat
 from textwrap import dedent
 
 import pytest
-from infrahouse_toolkit.terraform import terraform_apply
+from pytest_infrahouse import terraform_apply
 
 from tests.conftest import (
-    TEST_ZONE,
     UBUNTU_CODENAME,
-    TRACE_TERRAFORM,
     TEST_TIMEOUT,
     wait_for_instance_refresh,
     LOG,
@@ -22,6 +20,7 @@ def test_lb(
     autoscaling_client,
     keep_after,
     aws_region,
+    test_zone_name,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -34,7 +33,7 @@ def test_lb(
             dedent(
                 f"""
                 region          = "{aws_region}"
-                dns_zone        = "{TEST_ZONE}"
+                dns_zone        = "{test_zone_name}"
                 ubuntu_codename = "{UBUNTU_CODENAME}"
 
                 lb_subnet_ids       = {json.dumps(subnet_public_ids)}
@@ -48,7 +47,6 @@ def test_lb(
         terraform_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         asg_name = tf_output["asg_name"]["value"]
         wait_for_instance_refresh(asg_name, autoscaling_client)

--- a/tests/test_update_dns.py
+++ b/tests/test_update_dns.py
@@ -3,12 +3,10 @@ from os import path as osp
 from textwrap import dedent
 
 import pytest
-from infrahouse_toolkit.terraform import terraform_apply
+from pytest_infrahouse import terraform_apply
 
 from tests.conftest import (
-    TEST_ZONE,
     UBUNTU_CODENAME,
-    TRACE_TERRAFORM,
     TEST_TIMEOUT,
 )
 
@@ -18,6 +16,7 @@ def test_update_dns(
     service_network,
     keep_after,
     aws_region,
+    test_zone_name,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -31,7 +30,7 @@ def test_update_dns(
             dedent(
                 f"""
                 region          = "{aws_region}"
-                dns_zone        = "{TEST_ZONE}"
+                dns_zone        = "{test_zone_name}"
                 ubuntu_codename = "{UBUNTU_CODENAME}"
                 tags = {{
                     Name: "{instance_name}"
@@ -48,7 +47,6 @@ def test_update_dns(
         terraform_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         assert len(tf_output["network_subnet_private_ids"]) == 3
         assert len(tf_output["network_subnet_public_ids"]) == 3
@@ -59,7 +57,7 @@ def test_update_dns(
                 dedent(
                     f"""
                         region          = "{aws_region}"
-                        dns_zone        = "{TEST_ZONE}"
+                        dns_zone        = "{test_zone_name}"
                         ubuntu_codename = "{UBUNTU_CODENAME}"
                         tags = {{
                             Name: "{instance_name}"
@@ -77,6 +75,5 @@ def test_update_dns(
             terraform_dir,
             destroy_after=not keep_after,
             json_output=True,
-            enable_trace=TRACE_TERRAFORM,
         ):
             assert True


### PR DESCRIPTION
  - Update main terraform.tf to support AWS provider >= 5.11, < 7.0
  - Add parametrized testing for both AWS provider ~> 5.31 and ~> 6.0
  - Update instance-profile module to version 1.9.0 for v6 compatibility
  - Add SSL certificate dependencies on CAA records
  - Switch test data to use Ubuntu Pro AMIs
  - Add Makefile targets for testing specific provider versions
  - Clean up test dependencies and configuration
