### PR TITLE
fix: use ternary operator in validations for Terraform 1.12.2 compatibility

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -631,7 +631,7 @@ variable "alarm_target_response_time_threshold" {
   default     = null
 
   validation {
-    condition     = var.alarm_target_response_time_threshold == null || (var.alarm_target_response_time_threshold > 0 && var.alarm_target_response_time_threshold <= 3600)
+    condition     = var.alarm_target_response_time_threshold == null ? true : (var.alarm_target_response_time_threshold > 0 && var.alarm_target_response_time_threshold <= 3600)
     error_message = <<-EOF
       Response time threshold must be between 0 and 3600 seconds (1 hour).
       Upper limit is generous to support edge cases like file uploads, batch processing,
@@ -737,7 +737,7 @@ variable "alarm_cpu_utilization_threshold" {
   default     = null
 
   validation {
-    condition     = var.alarm_cpu_utilization_threshold == null || (var.alarm_cpu_utilization_threshold > 0 && var.alarm_cpu_utilization_threshold < 100)
+    condition     = var.alarm_cpu_utilization_threshold == null ? true : (var.alarm_cpu_utilization_threshold > 0 && var.alarm_cpu_utilization_threshold < 100)
     error_message = <<-EOF
       CPU utilization threshold must be between 0 and 99 (percentage).
       Threshold of 100 would never trigger since the alarm uses GreaterThanThreshold comparison.


### PR DESCRIPTION
Fixes validation errors in Terraform 1.12.2 when variables are null:
"Error during operation: argument must not be null."

The || operator doesn't properly short-circuit in validation blocks
in Terraform 1.12.2, causing both sides of the condition to be evaluated
even when the first condition (null check) is true.

Changed validations to use ternary operator pattern which reliably
short-circuits across all Terraform versions:
- Before: var.x == null || (var.x > 0 && var.x < 100)
- After:  var.x == null ? true : (var.x > 0 && var.x < 100)

Affected variables:
- alarm_cpu_utilization_threshold (variables.tf:740)
- alarm_target_response_time_threshold (variables.tf:634)

This pattern has been used successfully in other variables
(e.g., duration_threshold_percent in terraform-aws-lambda) and
is compatible with both Terraform 1.12.2 (production) and 1.13.3+ (tests).
