### PR TITLE
feat: Add load_balancing_algorithm_type variable for target group

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ make validate   # Validate Terraform configuration
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.23.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.23.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | >= 5.11, < 7.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
 
 ## Modules
 
@@ -360,6 +360,7 @@ make validate   # Validate Terraform configuration
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instances type | `string` | `"t3.micro"` | no |
 | <a name="input_internet_gateway_id"></a> [internet\_gateway\_id](#input\_internet\_gateway\_id) | Not used, but AWS Internet Gateway must be present. Ensure by passing its id. | `string` | n/a | yes |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | SSH keypair name to be deployed in EC2 instances | `string` | n/a | yes |
+| <a name="input_load_balancing_algorithm_type"></a> [load\_balancing\_algorithm\_type](#input\_load\_balancing\_algorithm\_type) | Load balancing algorithm for the target group.<br/><br/>**Available algorithms:**<br/>- `round_robin` (default): Distributes requests evenly across healthy targets.<br/>  Best for: General-purpose workloads with similar request processing times.<br/><br/>- `least_outstanding_requests`: Routes to the target with fewest in-flight requests.<br/>  Best for: Workloads with varying request processing times, long-running requests,<br/>  or when backend instances have different capacities.<br/><br/>**Note:** When stickiness is enabled, the algorithm applies only to initial<br/>session assignment. Subsequent requests from the same client go to the same target. | `string` | `"round_robin"` | no |
 | <a name="input_max_instance_lifetime_days"></a> [max\_instance\_lifetime\_days](#input\_max\_instance\_lifetime\_days) | The maximum amount of time, in \_days\_, that an instance can be in service, values must be either equal to 0 or between 7 and 365 days. | `number` | `30` | no |
 | <a name="input_min_healthy_percentage"></a> [min\_healthy\_percentage](#input\_min\_healthy\_percentage) | Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `100` | no |
 | <a name="input_on_demand_base_capacity"></a> [on\_demand\_base\_capacity](#input\_on\_demand\_base\_capacity) | If specified, the ASG will request spot instances and this will be the minimal number of on-demand instances. | `number` | `null` | no |
@@ -409,6 +410,7 @@ make validate   # Validate Terraform configuration
 | <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | Load Balancer ARN |
 | <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | Load balancer DNS name. |
 | <a name="output_load_balancer_security_groups"></a> [load\_balancer\_security\_groups](#output\_load\_balancer\_security\_groups) | Security groups associated with the load balancer |
+| <a name="output_load_balancing_algorithm_type"></a> [load\_balancing\_algorithm\_type](#output\_load\_balancing\_algorithm\_type) | Load balancing algorithm used by the target group (round\_robin or least\_outstanding\_requests). |
 | <a name="output_ssl_listener_arn"></a> [ssl\_listener\_arn](#output\_ssl\_listener\_arn) | SSL listener ARN |
 | <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | Target group ARN that listens to the service port. |
 | <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | Zone id where A records are created for the service. |

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,8 @@ resource "aws_alb_target_group" "website" {
   target_type          = var.target_group_type
   vpc_id               = data.aws_subnet.selected.vpc_id
   deregistration_delay = var.target_group_deregistration_delay
+
+  load_balancing_algorithm_type = var.load_balancing_algorithm_type
   stickiness {
     type    = "lb_cookie"
     enabled = var.stickiness_enabled

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "target_group_arn" {
   value       = aws_alb_target_group.website.arn
 }
 
+output "load_balancing_algorithm_type" {
+  description = "Load balancing algorithm used by the target group (round_robin or least_outstanding_requests)."
+  value       = aws_alb_target_group.website.load_balancing_algorithm_type
+}
+
 output "zone_id" {
   description = "Zone id where A records are created for the service."
   value       = aws_alb.website.zone_id

--- a/tests/test_create_lb.py
+++ b/tests/test_create_lb.py
@@ -7,11 +7,11 @@ import boto3
 import pytest
 import requests
 from pytest_infrahouse import terraform_apply
+from pytest_infrahouse.utils import wait_for_instance_refresh
 
 from tests.conftest import (
     LOG,
     TEST_TIMEOUT,
-    wait_for_instance_refresh,
     UBUNTU_CODENAME,
 )
 

--- a/variables.tf
+++ b/variables.tf
@@ -422,6 +422,30 @@ variable "target_group_type" {
   }
 }
 
+variable "load_balancing_algorithm_type" {
+  description = <<-EOF
+    Load balancing algorithm for the target group.
+
+    **Available algorithms:**
+    - `round_robin` (default): Distributes requests evenly across healthy targets.
+      Best for: General-purpose workloads with similar request processing times.
+
+    - `least_outstanding_requests`: Routes to the target with fewest in-flight requests.
+      Best for: Workloads with varying request processing times, long-running requests,
+      or when backend instances have different capacities.
+
+    **Note:** When stickiness is enabled, the algorithm applies only to initial
+    session assignment. Subsequent requests from the same client go to the same target.
+  EOF
+  type        = string
+  default     = "round_robin"
+
+  validation {
+    condition     = contains(["round_robin", "least_outstanding_requests"], var.load_balancing_algorithm_type)
+    error_message = "load_balancing_algorithm_type must be either 'round_robin' or 'least_outstanding_requests'."
+  }
+}
+
 variable "target_group_deregistration_delay" {
   description = <<-EOF
     Time in seconds for ALB to wait before deregistering a target.


### PR DESCRIPTION
Support configurable load balancing algorithm with two options:
- round_robin (default): Even distribution across healthy targets
- least_outstanding_requests: Routes to target with fewest in-flight requests

The latter is better for workloads with varying request processing times
or when backend instances have different capacities.
