### PR TITLE
feat: add optional warm pool support to ASG

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -56,6 +56,17 @@ resource "aws_autoscaling_group" "website" {
     min_healthy_percentage = var.asg_min_healthy_percentage
     max_healthy_percentage = var.asg_max_healthy_percentage
   }
+  dynamic "warm_pool" {
+    for_each = var.warm_pool_state != null ? [1] : []
+    content {
+      pool_state                  = var.warm_pool_state
+      min_size                    = var.warm_pool_min_size
+      max_group_prepared_capacity = var.warm_pool_max_group_prepared_capacity
+      instance_reuse_policy {
+        reuse_on_scale_in = var.warm_pool_reuse_on_scale_in
+      }
+    }
+  }
   dynamic "tag" {
     for_each = merge(
       local.default_asg_tags,

--- a/variables.tf
+++ b/variables.tf
@@ -972,3 +972,57 @@ variable "alarm_evaluation_periods" {
     error_message = "Evaluation periods must be at least 1"
   }
 }
+
+# ----------------------------------------------------------------------
+# Warm pool
+# ----------------------------------------------------------------------
+
+variable "warm_pool_state" {
+  description = <<-EOF
+    Pool state for the ASG warm pool. When set, enables a warm pool of pre-
+    initialized instances that resume in seconds rather than running cloud-init
+    from scratch on scale-out. Set to null to disable the warm pool entirely.
+
+    Valid values: `Stopped`, `Running`, `Hibernated`.
+
+    Note: `Hibernated` requires the AMI/instance type to support hibernation
+    and is **not supported on bare-metal instance types** (e.g. `*.metal`).
+    For bare-metal use `Stopped`.
+  EOF
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.warm_pool_state == null || contains(["Stopped", "Running", "Hibernated"], coalesce(var.warm_pool_state, "Stopped"))
+    error_message = "warm_pool_state must be one of: Stopped, Running, Hibernated."
+  }
+}
+
+variable "warm_pool_min_size" {
+  description = <<-EOF
+    Minimum number of instances to keep in the warm pool. Only takes effect
+    when `warm_pool_state` is set.
+  EOF
+  type        = number
+  default     = 0
+}
+
+variable "warm_pool_max_group_prepared_capacity" {
+  description = <<-EOF
+    Maximum number of instances that are allowed to be in the warm pool or in
+    any state except Terminated for the ASG. Defaults to the AWS default
+    (ASG MaxSize) when null.
+  EOF
+  type        = number
+  default     = null
+}
+
+variable "warm_pool_reuse_on_scale_in" {
+  description = <<-EOF
+    Whether terminated instances from the ASG should be reused in the warm
+    pool. AWS default is false (instances are terminated, not pooled, on
+    scale-in).
+  EOF
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds optional EC2 Auto Scaling **warm pool** support to the website ASG via four new input variables, gated on `warm_pool_state`. When `warm_pool_state` is null (default), no warm pool is configured — fully backward-compatible.

## Why

Bare-metal ASGs running heavy cloud-init (apt updates, image pulls, service init) suffer from 5-10 minute cold-starts on scale-out. A warm pool of pre-initialized instances in `Stopped` state resumes in 30-60s because user-data is at `PER_INSTANCE` frequency and does not re-run on stop/start.

## What

**New variables** (`variables.tf`):
- `warm_pool_state` — string, default `null`. Valid: `Stopped`, `Running`, `Hibernated`. `null` disables.
- `warm_pool_min_size` — number, default `0`
- `warm_pool_max_group_prepared_capacity` — number, default `null` (AWS default = ASG `MaxSize`)
- `warm_pool_reuse_on_scale_in` — bool, default `false` (matches AWS default)

**`asg.tf`**: dynamic `warm_pool` block on `aws_autoscaling_group.website`, fires only when `warm_pool_state != null`.

## Notes

- `Hibernated` is documented in the variable description as **unsupported on bare-metal instance types** per [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/hibernating-prerequisites.html); for bare-metal users it's `Stopped`.
- Skipped adding a test under `tests/` since the existing test infra requires the maintainer's AWS test account/role; happy to add one if you can point me at a runnable scaffold.

## Test plan

- [x] `terraform fmt -check` clean
- [x] Backward-compat: existing consumers (with `warm_pool_state` unset / null) see zero plan diff
- [ ] `make test-clean` (couldn't run from a fork — requires the test role)