### PR TITLE
fix: add moved blocks for ALB security group ingress rules

### DIFF
--- a/moved.tf
+++ b/moved.tf
@@ -22,3 +22,13 @@ moved {
   from = aws_s3_bucket_policy.access_logs[0]
   to   = module.access_log.aws_s3_bucket_policy.this
 }
+
+moved {
+  from = aws_vpc_security_group_ingress_rule.alb_listener_port
+  to   = aws_vpc_security_group_ingress_rule.alb_listener_port["0.0.0.0/0"]
+}
+
+moved {
+  from = aws_vpc_security_group_ingress_rule.https
+  to   = aws_vpc_security_group_ingress_rule.https["0.0.0.0/0"]
+}


### PR DESCRIPTION
## Summary

- Add `moved` blocks for `alb_listener_port` and `https` security group ingress rules that changed from singleton to `for_each` in v6.0.0
- Without these, Terraform tries to destroy+create the rules, causing `InvalidPermission.Duplicate` errors because the new rules are created before the old ones are deleted
- With the moved blocks, Terraform renames the state keys instead of recreating the resources — no connectivity gap, no race condition

Discovered during infrahouse-website-infra upgrade to v6.0.0 (PR #62).

## Test plan

- [ ] `terraform plan` on an existing v5.x deployment shows "moved" instead of destroy+create for the two ingress rules
- [ ] `terraform apply` succeeds without `InvalidPermission.Duplicate` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)