### PR TITLE
fix: depend on access-log bucket policy before enabling ALB logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ make validate   # Validate Terraform configuration
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_access_log"></a> [access\_log](#module\_access\_log) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.6.0 |
-| <a name="module_athena_results"></a> [athena\_results](#module\_athena\_results) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.6.0 |
+| <a name="module_access_log"></a> [access\_log](#module\_access\_log) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.8.0 |
+| <a name="module_athena_results"></a> [athena\_results](#module\_athena\_results) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.8.0 |
 | <a name="module_instance_profile"></a> [instance\_profile](#module\_instance\_profile) | registry.infrahouse.com/infrahouse/instance-profile/aws | 1.9.0 |
 
 ## Resources

--- a/glue.tf
+++ b/glue.tf
@@ -8,7 +8,7 @@ resource "random_string" "glue_suffix" {
 module "athena_results" {
   count   = local.glue_enabled ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
-  version = "0.6.0"
+  version = "0.8.0"
 
   bucket_prefix = "${var.alb_name_prefix}-athena-results-"
   force_destroy = var.alb_access_log_force_destroy

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,12 @@ resource "aws_alb" "website" {
     aws_security_group.alb.id
   ]
   access_logs {
-    bucket  = module.access_log.bucket_name
+    # Use the policy-aware output so the ALB depends on the bucket policy being
+    # attached before access logging is enabled. ELB performs a synchronous test
+    # PutObject when logging is turned on; referencing bucket_name (which only
+    # depends on the bucket, not its policy) races the policy and fails the first
+    # apply with "Access Denied". See issue #122.
+    bucket  = module.access_log.bucket_name_with_policy
     enabled = true
   }
   tags = merge(

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 module "access_log" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
-  version = "0.6.0"
+  version = "0.8.0"
 
   bucket_prefix      = "${var.alb_name_prefix}-access-log-"
   bucket_policy      = data.aws_iam_policy_document.access_logs.json


### PR DESCRIPTION
Closes #122.

## Problem

On **first creation**, `terraform apply` intermittently failed because the ALB enabled access logging before the access-log bucket **policy** was attached. ELB performs a synchronous test `PutObject` when access logs are turned on, and `aws_alb.website`'s `access_logs.bucket` referenced `module.access_log.bucket_name` — which depends only on the **bucket**, not on `aws_s3_bucket_policy.this`. Terraform's graph therefore allowed `ModifyLoadBalancerAttributes` (→ test `PutObject`) to run before the policy was attached, producing:

```
InvalidConfigurationRequest: Access Denied for bucket: <prefix>-access-log-<suffix>
```

A second apply succeeded (the policy now existed), confirming it was purely an ordering race — nasty in CI/CD where the first automated apply red-fails.

## Fix

Thread a **real data dependency** rather than a coarse `depends_on`:

1. Bump `infrahouse/s3-bucket/aws` `0.6.0 → 0.8.0`, which adds the `bucket_name_with_policy` output (value sourced from `aws_s3_bucket_policy.this.id` — upstream issue [infrahouse/terraform-aws-s3-bucket#29](https://github.com/infrahouse/terraform-aws-s3-bucket/issues/29)).
2. Point the ALB's `access_logs.bucket` at `module.access_log.bucket_name_with_policy`. The value is identical to `bucket_name`, but referencing it makes the ALB depend on the policy being attached — closing the race at the graph level.
3. Align the `athena_results` bucket to `0.8.0` as well, so the module uses a single `s3-bucket` version (no behavior change — the intervening 0.7.0 only added opt-in Object Lock, and 0.8.0 added the output; neither introduces required variables).

## Why not `depends_on = [module.access_log]`

A module-level `depends_on` would work but is coarse and couples the ALB to the entire bucket module. The policy-derived output expresses exactly the dependency that was missing, which is why this was sequenced behind the upstream output landing.

## Testing

This is an ordering race that can't be reproduced deterministically in a unit test (it depends on apply-time graph scheduling). The existing `tests/test_create_lb.py` already exercises the full first-time apply with access logging enabled (and validates log delivery via Athena), so it covers the path the fix makes reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)