### PR TITLE
feat: GPU ECS autoscaling support (targeted ODCR + optional CPU policy)

### DIFF
--- a/.claude/plans/gpu-ecs-support-odcr-and-cpu-policy-toggle.md
+++ b/.claude/plans/gpu-ecs-support-odcr-and-cpu-policy-toggle.md
@@ -1,0 +1,156 @@
+# website-pod changes for GPU ECS autoscaling
+
+**Module:** terraform-aws-website-pod (current v6.2.0)
+**Requested by:** terraform-aws-ecs GPU-utilization-autoscaling work
+**Related plan:** `terraform-aws-ecs/.claude/plans/gpu-utilization-autoscaling.md`
+**Suggested bump:** minor — both changes default to current behavior
+
+---
+
+## Why
+
+terraform-aws-ecs is adding native GPU-utilization autoscaling for GPU services
+(vLLM on `g5.2xlarge`). Two things it needs are owned by **this** module (the ASG and
+its launch template live here, not in terraform-aws-ecs), so they can't be done from
+the consumer side:
+
+1. **Bind the ASG to an On-Demand Capacity Reservation (ODCR)** so production keeps a
+   minimum number of GPU instances — requires a launch-template
+   `capacity_reservation_specification`, which this module does not expose today.
+2. **Let the consumer turn off the ASG host-CPU scaling policy** (`cpu_load`). For an
+   ECS capacity-provider-managed ASG, instance count is driven by ECS managed scaling
+   (`CapacityProviderReservation`). The `cpu_load` policy (`ASGAverageCPUUtilization`)
+   is a *second* controller on the same `DesiredCapacity` lever; on GPU hosts it
+   launches instances ECS has no task for (host CPU can't be relieved by adding an
+   instance — tasks don't migrate), which idle, dilute the CPU average, and fight
+   managed scaling. AWS advises against a custom ASG policy alongside managed scaling.
+   The consumer needs to disable it. (Full reasoning in the ecs-side plan, §1c.)
+
+Both are opt-in and default to today's behavior, so existing consumers see no change.
+
+---
+
+## Change 1 — Launch-template capacity reservation (targeted ODCR)
+
+**Today:** `aws_launch_template.website` (`asg.tf:83`) has no
+`capacity_reservation_specification` block and there is no variable for it. Confirmed
+by grep: no `capacity_reservation` string anywhere in the module.
+
+**Add** a variable and a gated dynamic block:
+
+```hcl
+# variables.tf
+variable "capacity_reservation_id" {
+  description = "Optional On-Demand Capacity Reservation ID to target from the launch template. When set, instances launch into this reservation (instance_match_criteria = targeted)."
+  type        = string
+  default     = null
+}
+
+variable "capacity_reservation_resource_group_arn" {
+  description = "Optional Capacity Reservation resource-group ARN to target (alternative to a single reservation ID)."
+  type        = string
+  default     = null
+}
+```
+
+```hcl
+# asg.tf, inside resource "aws_launch_template" "website"
+dynamic "capacity_reservation_specification" {
+  for_each = (var.capacity_reservation_id != null || var.capacity_reservation_resource_group_arn != null) ? [1] : []
+  content {
+    capacity_reservation_preference = "capacity-reservations-only" # or leave unset
+    capacity_reservation_target {
+      capacity_reservation_id                 = var.capacity_reservation_id
+      capacity_reservation_resource_group_arn = var.capacity_reservation_resource_group_arn
+    }
+  }
+}
+```
+
+Notes:
+- Both vars default `null` → `for_each` empty → block absent → byte-identical launch
+  template for existing consumers.
+- Validate mutual exclusivity (id XOR resource-group ARN) in a `validation` block.
+- Decide the `capacity_reservation_preference` default; AWS rejects setting
+  `preference` and `target` together in some combinations — test both shapes.
+
+---
+
+## Change 2 — Make the `cpu_load` ASG policy optional
+
+**Today:** `aws_autoscaling_policy.cpu_load` (`autoscaling.tf:1`) is created
+**unconditionally** for every ASG, target `var.autoscaling_target_cpu_load` (default
+60, `variables.tf:300`).
+
+**Add** a toggle and gate the resource:
+
+```hcl
+# variables.tf
+variable "create_cpu_scaling_policy" {
+  description = "Whether to create the ASG host-CPU target-tracking policy (ASGAverageCPUUtilization). Set false when instance count is managed elsewhere (e.g. an ECS capacity provider's managed scaling), where a second ASG policy conflicts."
+  type        = bool
+  default     = true
+}
+```
+
+```hcl
+# autoscaling.tf
+resource "aws_autoscaling_policy" "cpu_load" {
+  count                  = var.create_cpu_scaling_policy ? 1 : 0
+  autoscaling_group_name = aws_autoscaling_group.website.name
+  ...
+}
+```
+
+### Migration subtlety — needs a `moved` block
+
+Adding `count` changes the resource address from `aws_autoscaling_policy.cpu_load` to
+`aws_autoscaling_policy.cpu_load[0]`. Without a migration, existing states would
+**destroy and recreate** the policy. Add to `moved.tf`:
+
+```hcl
+moved {
+  from = aws_autoscaling_policy.cpu_load
+  to   = aws_autoscaling_policy.cpu_load[0]
+}
+```
+
+This is a no-op for consumers who keep the default (`true`).
+
+### Related: the CPU alarm premise
+
+`alarms.tf` derives a CPU alarm threshold from `autoscaling_target_cpu_load` on the
+premise "CPU high → ASG launches instances; if it stays high, autoscaling failed"
+(`variables.tf:894+`). When `create_cpu_scaling_policy = false`, that premise no
+longer holds — the alarm would misfire/mislead. Decide whether to also gate or
+reword that alarm when the policy is off. At minimum, note it; ideally gate it on the
+same toggle.
+
+---
+
+## Consumer side (terraform-aws-ecs) — for reference
+
+Once released, terraform-aws-ecs will:
+- Pass `capacity_reservation_id` through from its own `gpu_capacity_reservation_id`
+  variable (targeted-ODCR path).
+- Set `create_cpu_scaling_policy = var.gpu_count == 0` (off for GPU services), so ECS
+  managed scaling is the sole instance driver.
+
+Until this ships, the ecs-side plan uses fallbacks: **open** ODCR (no launch-template
+change) and neutralizing `cpu_load` by passing a never-fires target
+(`autoscaling_target_cpu_load = 99` when `gpu_count > 0`). These changes replace both
+fallbacks with the clean path.
+
+---
+
+## Checklist
+
+- [ ] Add `capacity_reservation_id` / `capacity_reservation_resource_group_arn` vars
+- [ ] Add gated `capacity_reservation_specification` dynamic block to the launch template
+- [ ] Validate id XOR resource-group-ARN; test `capacity_reservation_preference` shapes
+- [ ] Add `create_cpu_scaling_policy` var; gate `aws_autoscaling_policy.cpu_load` with `count`
+- [ ] Add `moved` block for `cpu_load` → `cpu_load[0]`
+- [ ] Decide/handle the CPU alarm when the policy is disabled
+- [ ] Confirm defaults keep existing plans byte-identical (no-op for current consumers)
+- [ ] Read `.claude/CODING_STANDARD.md` before writing code
+- [ ] `terraform fmt -recursive`, `make validate`; minor version bump

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ ENV/
 pytest-*-output.log
 docs/_build/
 
+# MkDocs build output
+site/
+
 # IDE
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ module "website" {
   backend_subnets       = module.website-vpc.subnet_private_ids
   zone_id               = "Z07662251LH3YRF2ERM3G"
   dns_a_records         = ["", "www"]
-  internet_gateway_id   = module.website-vpc.internet_gateway_id
   key_pair_name         = data.aws_key_pair.aleks.key_name
   subnets               = module.website-vpc.subnet_public_ids
   userdata              = module.webserver_userdata.userdata
+  replication_region    = "us-east-1"
   stickiness_enabled    = true
 }
 ```
@@ -146,26 +146,27 @@ who can access your load balancer on both HTTP (port 80/`var.alb_listener_port`)
 
 ### ALB Access Logging (Security Best Practice)
 
-**Recommended:** Enable ALB access logging for security investigations, incident response, debugging, and compliance requirements.
+ALB access logging is **always enabled** — the module provisions an encrypted, versioned,
+cross-region-replicated S3 bucket that stores detailed ALB access logs. Access logs are
+mandated by SOC2/ISO 27001 and are not optional. Tune the behavior with:
 
 ```hcl
 module "website" {
   # ... other configuration ...
 
-  # Enable access logging (recommended for production)
-  alb_access_log_enabled = true
+  replication_region             = "us-east-1"  # Region for the replica bucket (required)
+  alb_access_log_expiration_days = 365           # Retention (default: 365)
+  alb_access_log_force_destroy   = false         # Delete bucket even if non-empty (default: false)
 }
 ```
 
-When enabled, the module creates an encrypted, versioned S3 bucket that stores detailed ALB access logs. These logs are essential for:
+These logs are essential for:
 - **Security:** Track unauthorized access attempts and identify suspicious traffic patterns
 - **Compliance:** Meet SOC2, HIPAA, PCI-DSS, and ISO 27001 requirements
 - **Operations:** Debug production issues and analyze traffic patterns
 - **AWS Best Practices:** Aligns with AWS Well-Architected Framework security pillar
 
 **Cost Impact:** Minimal (~$4/year for moderate traffic). Storage costs are negligible compared to security and compliance benefits.
-
-**Note:** Starting in v6.0.0, access logging will be enabled by default. See `variables.tf` for details.
 
 ### Querying Access Logs with Athena
 
@@ -175,7 +176,6 @@ When access logging is enabled, you can optionally set up Athena to query the lo
 module "website" {
   # ... other configuration ...
 
-  alb_access_log_enabled        = true
   alb_access_log_athena_enabled = true
 }
 ```
@@ -213,42 +213,12 @@ LIMIT 50;
 Replace `<service_name>` with your `service_name` value (hyphens replaced with underscores).
 Select the Athena workgroup named `<service_name>-alb-logs-<suffix>` before running queries.
 
-## Deprecated Variables
+## Upgrading
 
-The following variables contain typos and are deprecated. They will be removed in **v6.0.0**.
-
-| Deprecated Variable (v5.x)          | Correct Variable (Use This)          | Status                    |
-|-------------------------------------|--------------------------------------|---------------------------|
-| `alb_healthcheck_uhealthy_threshold`| `alb_healthcheck_unhealthy_threshold`| ⚠️  Deprecated in v5.11.0 |
-| `attach_tagret_group_to_asg`        | `attach_target_group_to_asg`         | ⚠️  Deprecated in v5.11.0 |
-
-### Migration Instructions
-
-If you're using the deprecated variables, update your code before upgrading to v6.0.0:
-
-**Before:**
-```hcl
-module "website" {
-  source  = "infrahouse/website-pod/aws"
-  version = "~> 5.0"
-
-  alb_healthcheck_uhealthy_threshold = 3  # Typo: "uhealthy"
-  attach_tagret_group_to_asg         = true  # Typo: "tagret"
-}
-```
-
-**After:**
-```hcl
-module "website" {
-  source  = "infrahouse/website-pod/aws"
-  version = "~> 5.11"  # or "~> 6.0" when available
-
-  alb_healthcheck_unhealthy_threshold = 3  # Correct spelling
-  attach_target_group_to_asg          = true  # Correct spelling
-}
-```
-
-For detailed migration guidance, see [UPGRADE-6.0.md](UPGRADE-6.0.md).
+The v5.x typo'd variables (`alb_healthcheck_uhealthy_threshold`, `attach_tagret_group_to_asg`)
+were removed in v6.0.0 in favor of their correctly-spelled counterparts
+(`alb_healthcheck_unhealthy_threshold`, `attach_target_group_to_asg`).
+For migration guidance from v5.x, see [UPGRADE-6.0.md](UPGRADE-6.0.md).
 
 ## Development and Testing
 
@@ -414,36 +384,38 @@ make validate   # Validate Terraform configuration
 | <a name="input_alb_healthcheck_interval"></a> [alb\_healthcheck\_interval](#input\_alb\_healthcheck\_interval) | Number of seconds between checks | `number` | `5` | no |
 | <a name="input_alb_healthcheck_path"></a> [alb\_healthcheck\_path](#input\_alb\_healthcheck\_path) | Path on the webserver that the elb will check to determine whether the instance is healthy or not | `string` | `"/index.html"` | no |
 | <a name="input_alb_healthcheck_port"></a> [alb\_healthcheck\_port](#input\_alb\_healthcheck\_port) | Port of the webserver that the elb will check to determine whether the instance is healthy or not | `any` | `80` | no |
-| <a name="input_alb_healthcheck_protocol"></a> [alb\_healthcheck\_protocol](#input\_alb\_healthcheck\_protocol) | Protocol to use with the webserver that the elb will check to determine whether the instance is healthy or not | `string` | `"HTTP"` | no |
+| <a name="input_alb_healthcheck_protocol"></a> [alb\_healthcheck\_protocol](#input\_alb\_healthcheck\_protocol) | Protocol to use with the webserver that the elb will check to determine whether the<br/>instance is healthy or not | `string` | `"HTTP"` | no |
 | <a name="input_alb_healthcheck_response_code_matcher"></a> [alb\_healthcheck\_response\_code\_matcher](#input\_alb\_healthcheck\_response\_code\_matcher) | Range of http return codes that can match | `string` | `"200-299"` | no |
 | <a name="input_alb_healthcheck_timeout"></a> [alb\_healthcheck\_timeout](#input\_alb\_healthcheck\_timeout) | Number of seconds to timeout a check | `number` | `4` | no |
 | <a name="input_alb_healthcheck_unhealthy_threshold"></a> [alb\_healthcheck\_unhealthy\_threshold](#input\_alb\_healthcheck\_unhealthy\_threshold) | Number of consecutive health check failures required before considering the target unhealthy | `number` | `2` | no |
 | <a name="input_alb_idle_timeout"></a> [alb\_idle\_timeout](#input\_alb\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
 | <a name="input_alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#input\_alb\_ingress\_cidr\_blocks) | List of CIDR blocks allowed to access the ALB. Defaults to allow all (0.0.0.0/0). | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
-| <a name="input_alb_listener_port"></a> [alb\_listener\_port](#input\_alb\_listener\_port) | TCP port that a load balancer listens to to serve client HTTP requests. The load balancer redirects this port to 443 and HTTPS. | `number` | `80` | no |
+| <a name="input_alb_listener_port"></a> [alb\_listener\_port](#input\_alb\_listener\_port) | TCP port that a load balancer listens to to serve client HTTP requests. The load<br/>balancer redirects this port to 443 and HTTPS. | `number` | `80` | no |
 | <a name="input_alb_name_prefix"></a> [alb\_name\_prefix](#input\_alb\_name\_prefix) | Name prefix for the load balancer | `string` | `"web"` | no |
 | <a name="input_allow_wildcard_certificates"></a> [allow\_wildcard\_certificates](#input\_allow\_wildcard\_certificates) | If true, CAA records will allow wildcard certificates from the configured certificate\_issuers.<br/>If false, wildcard certificates are blocked. | `bool` | `false` | no |
 | <a name="input_ami"></a> [ami](#input\_ami) | Image for EC2 instances | `string` | n/a | yes |
 | <a name="input_asg_default_cooldown"></a> [asg\_default\_cooldown](#input\_asg\_default\_cooldown) | Amount of time, in seconds, after a scaling activity completes before another<br/>scaling activity can start. This prevents rapid scale-in/scale-out cycles. | `number` | `300` | no |
 | <a name="input_asg_enabled_metrics"></a> [asg\_enabled\_metrics](#input\_asg\_enabled\_metrics) | List of ASG metrics to enable for CloudWatch monitoring.<br/>Set to empty list to disable metrics collection.<br/><br/>Available metrics:<br/>- GroupDesiredCapacity<br/>- GroupInServiceInstances<br/>- GroupPendingInstances<br/>- GroupTerminatingInstances<br/>- GroupTotalInstances<br/>- GroupMinSize<br/>- GroupMaxSize<br/>- GroupInServiceCapacity<br/>- GroupPendingCapacity<br/>- GroupStandbyCapacity<br/>- GroupStandbyInstances<br/>- GroupTerminatingCapacity<br/>- GroupTotalCapacity<br/>- WarmPoolDesiredCapacity<br/>- WarmPoolWarmedCapacity<br/>- WarmPoolPendingCapacity<br/>- WarmPoolTerminatingCapacity<br/>- WarmPoolTotalCapacity<br/>- WarmPoolMinSize<br/>- GroupAndWarmPoolDesiredCapacity<br/>- GroupAndWarmPoolTotalCapacity | `list(string)` | <pre>[<br/>  "GroupDesiredCapacity",<br/>  "GroupInServiceInstances",<br/>  "GroupPendingInstances",<br/>  "GroupTerminatingInstances",<br/>  "GroupTotalInstances"<br/>]</pre> | no |
-| <a name="input_asg_lifecycle_hook_heartbeat_timeout"></a> [asg\_lifecycle\_hook\_heartbeat\_timeout](#input\_asg\_lifecycle\_hook\_heartbeat\_timeout) | How much time in seconds to wait until the hook is completed before proceeding with the default action. | `number` | `3600` | no |
+| <a name="input_asg_lifecycle_hook_heartbeat_timeout"></a> [asg\_lifecycle\_hook\_heartbeat\_timeout](#input\_asg\_lifecycle\_hook\_heartbeat\_timeout) | How much time in seconds to wait until the hook is completed before proceeding with<br/>the default action. | `number` | `3600` | no |
 | <a name="input_asg_lifecycle_hook_initial"></a> [asg\_lifecycle\_hook\_initial](#input\_asg\_lifecycle\_hook\_initial) | Name for an initial LAUNCHING lifecycle hook configured via the initial\_lifecycle\_hook<br/>block in the ASG. This hook is evaluated during ASG creation.<br/>Only one initial hook is allowed per ASG.<br/><br/>Use this for simple lifecycle hooks that don't require additional configuration. | `string` | `null` | no |
 | <a name="input_asg_lifecycle_hook_launching"></a> [asg\_lifecycle\_hook\_launching](#input\_asg\_lifecycle\_hook\_launching) | Name for a LAUNCHING lifecycle hook configured via a separate<br/>aws\_autoscaling\_lifecycle\_hook resource. This allows for more complex configurations<br/>and can be created after the ASG exists.<br/><br/>Use this if you need to attach SNS notifications or additional settings to the lifecycle hook. | `string` | `null` | no |
 | <a name="input_asg_lifecycle_hook_launching_default_result"></a> [asg\_lifecycle\_hook\_launching\_default\_result](#input\_asg\_lifecycle\_hook\_launching\_default\_result) | Default result for launching lifecycle hook. | `string` | `"ABANDON"` | no |
 | <a name="input_asg_lifecycle_hook_terminating"></a> [asg\_lifecycle\_hook\_terminating](#input\_asg\_lifecycle\_hook\_terminating) | Create a TERMINATING lifecycle hook with this name. | `string` | `null` | no |
 | <a name="input_asg_lifecycle_hook_terminating_default_result"></a> [asg\_lifecycle\_hook\_terminating\_default\_result](#input\_asg\_lifecycle\_hook\_terminating\_default\_result) | Default result for terminating lifecycle hook. | `string` | `"ABANDON"` | no |
-| <a name="input_asg_max_healthy_percentage"></a> [asg\_max\_healthy\_percentage](#input\_asg\_max\_healthy\_percentage) | Specifies the upper limit on the number of instances that are in the InService or Pending state with a healthy status during an instance replacement activity. | `number` | `200` | no |
+| <a name="input_asg_max_healthy_percentage"></a> [asg\_max\_healthy\_percentage](#input\_asg\_max\_healthy\_percentage) | Specifies the upper limit on the number of instances that are in the InService or<br/>Pending state with a healthy status during an instance replacement activity. | `number` | `200` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG | `number` | `10` | no |
-| <a name="input_asg_min_elb_capacity"></a> [asg\_min\_elb\_capacity](#input\_asg\_min\_elb\_capacity) | Terraform will wait until this many EC2 instances in the autoscaling group become healthy. By default, it's equal to var.asg\_min\_size. | `number` | `null` | no |
-| <a name="input_asg_min_healthy_percentage"></a> [asg\_min\_healthy\_percentage](#input\_asg\_min\_healthy\_percentage) | Specifies the lower limit on the number of instances that must be in the InService state with a healthy status during an instance replacement activity. | `number` | `100` | no |
+| <a name="input_asg_min_elb_capacity"></a> [asg\_min\_elb\_capacity](#input\_asg\_min\_elb\_capacity) | Terraform will wait until this many EC2 instances in the autoscaling group become<br/>healthy. By default, it's equal to var.asg\_min\_size. | `number` | `null` | no |
+| <a name="input_asg_min_healthy_percentage"></a> [asg\_min\_healthy\_percentage](#input\_asg\_min\_healthy\_percentage) | Specifies the lower limit on the number of instances that must be in the InService<br/>state with a healthy status during an instance replacement activity. | `number` | `100` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of instances in ASG | `number` | `2` | no |
 | <a name="input_asg_name"></a> [asg\_name](#input\_asg\_name) | Autoscaling group name, if provided. | `string` | `null` | no |
-| <a name="input_asg_scale_in_protected_instances"></a> [asg\_scale\_in\_protected\_instances](#input\_asg\_scale\_in\_protected\_instances) | Behavior when encountering instances protected from scale in are found. Available behaviors are Refresh, Ignore, and Wait. | `string` | `"Ignore"` | no |
+| <a name="input_asg_scale_in_protected_instances"></a> [asg\_scale\_in\_protected\_instances](#input\_asg\_scale\_in\_protected\_instances) | Behavior when encountering instances protected from scale in are found. Available<br/>behaviors are Refresh, Ignore, and Wait. | `string` | `"Ignore"` | no |
 | <a name="input_assume_dns"></a> [assume\_dns](#input\_assume\_dns) | If True, create DNS records provided by var.dns\_a\_records. | `bool` | `true` | no |
-| <a name="input_attach_target_group_to_asg"></a> [attach\_target\_group\_to\_asg](#input\_attach\_target\_group\_to\_asg) | Whether to register ASG instances in the target group. Disable if using ECS which registers targets itself. | `bool` | `true` | no |
-| <a name="input_autoscaling_target_cpu_load"></a> [autoscaling\_target\_cpu\_load](#input\_autoscaling\_target\_cpu\_load) | Target CPU load for autoscaling | `number` | `60` | no |
+| <a name="input_attach_target_group_to_asg"></a> [attach\_target\_group\_to\_asg](#input\_attach\_target\_group\_to\_asg) | Whether to register ASG instances in the target group. Disable if using ECS which<br/>registers targets itself. | `bool` | `true` | no |
+| <a name="input_autoscaling_target_cpu_load"></a> [autoscaling\_target\_cpu\_load](#input\_autoscaling\_target\_cpu\_load) | Target CPU load for the ASG host-CPU target-tracking policy (ASGAverageCPUUtilization).<br/>Set to null to not create the policy at all. Do this when instance count is managed<br/>elsewhere (e.g. an ECS capacity provider's managed scaling), where a second ASG policy<br/>on the same DesiredCapacity lever conflicts. The high-CPU CloudWatch alarm is always<br/>created for Vanta compliance; when this is null its threshold falls back to a fixed<br/>90% instead of target + 30%. | `number` | `60` | no |
 | <a name="input_backend_subnets"></a> [backend\_subnets](#input\_backend\_subnets) | Subnet ids where EC2 instances should be present | `list(string)` | n/a | yes |
-| <a name="input_certificate_issuers"></a> [certificate\_issuers](#input\_certificate\_issuers) | List of certificate authority domains allowed to issue certificates for this domain (e.g., ["amazon.com", "letsencrypt.org"]). The module will format these as CAA records. | `list(string)` | <pre>[<br/>  "amazon.com"<br/>]</pre> | no |
+| <a name="input_capacity_reservation_id"></a> [capacity\_reservation\_id](#input\_capacity\_reservation\_id) | Optional On-Demand Capacity Reservation ID to target from the launch template.<br/>When set, instances launch into this reservation (instance\_match\_criteria = targeted).<br/>Mutually exclusive with capacity\_reservation\_resource\_group\_arn. | `string` | `null` | no |
+| <a name="input_capacity_reservation_resource_group_arn"></a> [capacity\_reservation\_resource\_group\_arn](#input\_capacity\_reservation\_resource\_group\_arn) | Optional Capacity Reservation resource-group ARN to target from the launch template<br/>(an alternative to a single reservation ID).<br/>Mutually exclusive with capacity\_reservation\_id. | `string` | `null` | no |
+| <a name="input_certificate_issuers"></a> [certificate\_issuers](#input\_certificate\_issuers) | List of certificate authority domains allowed to issue certificates for this domain<br/>(e.g., ["amazon.com", "letsencrypt.org"]). The module will format these as CAA records. | `list(string)` | <pre>[<br/>  "amazon.com"<br/>]</pre> | no |
 | <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | Optional CPU options for the launch template. Set to null (default) to<br/>let AWS apply the instance-type defaults. `nested_virtualization` (one<br/>of "enabled" / "disabled") is only supported on Intel 8th-gen non-metal<br/>instance types — c8i, m8i, r8i (Feb 2026+). | <pre>object({<br/>    amd_sev_snp           = optional(string)<br/>    core_count            = optional(number)<br/>    nested_virtualization = optional(string)<br/>    threads_per_core      = optional(number)<br/>  })</pre> | `null` | no |
 | <a name="input_dns_a_records"></a> [dns\_a\_records](#input\_dns\_a\_records) | List of A records in the zone\_id that will resolve to the ALB dns name. | `list(string)` | <pre>[<br/>  ""<br/>]</pre> | no |
 | <a name="input_dns_routing_policy"></a> [dns\_routing\_policy](#input\_dns\_routing\_policy) | DNS routing policy for Route53 A records.<br/><br/>**Available policies:**<br/>- `simple` (default): Standard DNS routing. Each A record resolves directly to the ALB.<br/>  Best for: Single deployments, standard configurations.<br/><br/>- `weighted`: Enables Route53 weighted routing policy for zero-downtime migrations.<br/>  Requires: dns\_set\_identifier must be set.<br/>  Best for: Blue/green deployments, gradual traffic migration, A/B testing.<br/><br/>**Migration workflow example:**<br/>1. Deploy new service with `dns_routing_policy = "weighted"`, `dns_weight = 0`<br/>2. Convert existing service to weighted with `dns_weight = 100`<br/>3. Gradually shift: 90/10 → 50/50 → 10/90 → 0/100<br/>4. Remove old service<br/><br/>**Note:** When using weighted routing, you can have multiple modules create<br/>records for the same DNS name, each with a unique dns\_set\_identifier.<br/><br/>**Note:** This routing policy applies to ALL DNS records created via dns\_a\_records.<br/>If you need different routing policies per record, deploy separate module instances. | `string` | `"simple"` | no |
@@ -455,14 +427,14 @@ make validate   # Validate Terraform configuration
 | <a name="input_health_check_grace_period"></a> [health\_check\_grace\_period](#input\_health\_check\_grace\_period) | ASG will wait up to this number of seconds for instance to become healthy | `number` | `600` | no |
 | <a name="input_health_check_type"></a> [health\_check\_type](#input\_health\_check\_type) | Type of healthcheck the ASG uses. Can be EC2 or ELB. | `string` | `"ELB"` | no |
 | <a name="input_instance_profile_permissions"></a> [instance\_profile\_permissions](#input\_instance\_profile\_permissions) | A JSON policy document to attach to the instance profile.<br/>This should be the output of an aws\_iam\_policy\_document data source.<br/><br/>Example:<br/>  instance\_profile\_permissions = data.aws\_iam\_policy\_document.my\_policy.json<br/><br/>If not specified, defaults to a minimal policy allowing sts:GetCallerIdentity. | `string` | `null` | no |
-| <a name="input_instance_role_name"></a> [instance\_role\_name](#input\_instance\_role\_name) | If specified, the instance profile role will have this name. Otherwise, the role name will be generated. | `string` | `null` | no |
+| <a name="input_instance_role_name"></a> [instance\_role\_name](#input\_instance\_role\_name) | If specified, the instance profile role will have this name. Otherwise, the role name<br/>will be generated. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instances type | `string` | `"t3.micro"` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | SSH keypair name to be deployed in EC2 instances | `string` | n/a | yes |
 | <a name="input_load_balancing_algorithm_type"></a> [load\_balancing\_algorithm\_type](#input\_load\_balancing\_algorithm\_type) | Load balancing algorithm for the target group.<br/><br/>**Available algorithms:**<br/>- `round_robin` (default): Distributes requests evenly across healthy targets.<br/>  Best for: General-purpose workloads with similar request processing times.<br/><br/>- `least_outstanding_requests`: Routes to the target with fewest in-flight requests.<br/>  Best for: Workloads with varying request processing times, long-running requests,<br/>  or when backend instances have different capacities.<br/><br/>**Note:** When stickiness is enabled, the algorithm applies only to initial<br/>session assignment. Subsequent requests from the same client go to the same target. | `string` | `"round_robin"` | no |
-| <a name="input_max_instance_lifetime_days"></a> [max\_instance\_lifetime\_days](#input\_max\_instance\_lifetime\_days) | The maximum amount of time, in \_days\_, that an instance can be in service, values must be either equal to 0 or between 7 and 365 days. | `number` | `30` | no |
-| <a name="input_min_healthy_percentage"></a> [min\_healthy\_percentage](#input\_min\_healthy\_percentage) | Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. | `number` | `100` | no |
-| <a name="input_on_demand_base_capacity"></a> [on\_demand\_base\_capacity](#input\_on\_demand\_base\_capacity) | If specified, the ASG will request spot instances and this will be the minimal number of on-demand instances. | `number` | `null` | no |
-| <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Whether newly launched instances are automatically protected from termination by Amazon EC2 Auto Scaling when scaling in. | `bool` | `false` | no |
+| <a name="input_max_instance_lifetime_days"></a> [max\_instance\_lifetime\_days](#input\_max\_instance\_lifetime\_days) | The maximum amount of time, in \_days\_, that an instance can be in service, values must<br/>be either equal to 0 or between 7 and 365 days. | `number` | `30` | no |
+| <a name="input_min_healthy_percentage"></a> [min\_healthy\_percentage](#input\_min\_healthy\_percentage) | Amount of capacity in the Auto Scaling group that must remain healthy during an<br/>instance refresh to allow the operation to continue, as a percentage of the desired<br/>capacity of the Auto Scaling group. | `number` | `100` | no |
+| <a name="input_on_demand_base_capacity"></a> [on\_demand\_base\_capacity](#input\_on\_demand\_base\_capacity) | If specified, the ASG will request spot instances and this will be the minimal number<br/>of on-demand instances. | `number` | `null` | no |
+| <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Whether newly launched instances are automatically protected from termination by<br/>Amazon EC2 Auto Scaling when scaling in. | `bool` | `false` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | AWS region for cross-region replication of the ALB access log bucket. | `string` | n/a | yes |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | Root volume size in EC2 instance in Gigabytes | `number` | `30` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Descriptive name of a service that will use this VPC | `string` | `"website"` | no |
@@ -477,11 +449,11 @@ make validate   # Validate Terraform configuration
 | <a name="input_target_group_type"></a> [target\_group\_type](#input\_target\_group\_type) | Target group type: instance, ip, alb. Default is instance. | `string` | `"instance"` | no |
 | <a name="input_upstream_module"></a> [upstream\_module](#input\_upstream\_module) | Module that called this module. | `string` | `null` | no |
 | <a name="input_userdata"></a> [userdata](#input\_userdata) | userdata for cloud-init to provision EC2 instances | `string` | n/a | yes |
-| <a name="input_vanta_contains_ephi"></a> [vanta\_contains\_ephi](#input\_vanta\_contains\_ephi) | This tag allows administrators to define whether or not a resource contains electronically Protected Health Information (ePHI). It can be set to either (true) or if they do not have ephi data (false). | `bool` | `false` | no |
-| <a name="input_vanta_contains_user_data"></a> [vanta\_contains\_user\_data](#input\_vanta\_contains\_user\_data) | his tag allows administrators to define whether or not a resource contains user data (true) or if they do not contain user data (false). | `bool` | `false` | no |
-| <a name="input_vanta_description"></a> [vanta\_description](#input\_vanta\_description) | This tag allows administrators to set a description, for instance, or add any other descriptive information. | `string` | `null` | no |
-| <a name="input_vanta_no_alert"></a> [vanta\_no\_alert](#input\_vanta\_no\_alert) | Administrators can add this tag to mark a resource as out of scope for their audit. If this tag is added, the administrator will need to set a reason for why it's not relevant to their audit. | `string` | `null` | no |
-| <a name="input_vanta_owner"></a> [vanta\_owner](#input\_vanta\_owner) | The email address of the instance's owner, and it should be set to the email address of a user in Vanta. An owner will not be assigned if there is no user in Vanta with the email specified. | `string` | `null` | no |
+| <a name="input_vanta_contains_ephi"></a> [vanta\_contains\_ephi](#input\_vanta\_contains\_ephi) | This tag allows administrators to define whether or not a resource contains<br/>electronically Protected Health Information (ePHI). It can be set to either (true) or<br/>if they do not have ephi data (false). | `bool` | `false` | no |
+| <a name="input_vanta_contains_user_data"></a> [vanta\_contains\_user\_data](#input\_vanta\_contains\_user\_data) | This tag allows administrators to define whether or not a resource contains user data<br/>(true) or if they do not contain user data (false). | `bool` | `false` | no |
+| <a name="input_vanta_description"></a> [vanta\_description](#input\_vanta\_description) | This tag allows administrators to set a description, for instance, or add any other<br/>descriptive information. | `string` | `null` | no |
+| <a name="input_vanta_no_alert"></a> [vanta\_no\_alert](#input\_vanta\_no\_alert) | Administrators can add this tag to mark a resource as out of scope for their audit.<br/>If this tag is added, the administrator will need to set a reason for why it's not<br/>relevant to their audit. | `string` | `null` | no |
+| <a name="input_vanta_owner"></a> [vanta\_owner](#input\_vanta\_owner) | The email address of the instance's owner, and it should be set to the email address<br/>of a user in Vanta. An owner will not be assigned if there is no user in Vanta with<br/>the email specified. | `string` | `null` | no |
 | <a name="input_vanta_production_environments"></a> [vanta\_production\_environments](#input\_vanta\_production\_environments) | Environment names to consider production grade in Vanta. | `list(string)` | <pre>[<br/>  "production",<br/>  "prod"<br/>]</pre> | no |
 | <a name="input_vanta_user_data_stored"></a> [vanta\_user\_data\_stored](#input\_vanta\_user\_data\_stored) | This tag allows administrators to describe the type of user data the instance contains. | `string` | `null` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | How much time to wait until all instances are healthy | `string` | `"20m"` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -100,6 +100,18 @@ resource "aws_launch_template" "website" {
     http_endpoint          = "enabled"
     instance_metadata_tags = "enabled"
   }
+  # Target an On-Demand Capacity Reservation when one is provided. Only the target is
+  # set (not capacity_reservation_preference) so AWS uses instance_match_criteria =
+  # targeted. Both vars default null -> block absent -> byte-identical for existing consumers.
+  dynamic "capacity_reservation_specification" {
+    for_each = var.capacity_reservation_id != null || var.capacity_reservation_resource_group_arn != null ? [1] : []
+    content {
+      capacity_reservation_target {
+        capacity_reservation_id                 = var.capacity_reservation_id
+        capacity_reservation_resource_group_arn = var.capacity_reservation_resource_group_arn
+      }
+    }
+  }
   dynamic "cpu_options" {
     for_each = var.cpu_options == null ? [] : [var.cpu_options]
     content {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,4 +1,5 @@
 resource "aws_autoscaling_policy" "cpu_load" {
+  count                  = var.autoscaling_target_cpu_load != null ? 1 : 0
   autoscaling_group_name = aws_autoscaling_group.website.name
   name                   = aws_autoscaling_group.website.name
   policy_type            = "TargetTrackingScaling"

--- a/deprecations.tf
+++ b/deprecations.tf
@@ -39,10 +39,16 @@ check "weighted_routing_requires_set_identifier" {
   }
 }
 
-# Validate CPU alarm threshold is above autoscaling target
+# Validate CPU alarm threshold is above autoscaling target.
+# Skipped when autoscaling_target_cpu_load is null (host-CPU scaling policy disabled):
+# there is no target to compare against, and comparing a number to null errors.
 check "cpu_alarm_threshold_sane" {
   assert {
-    condition     = local.alarm_cpu_threshold > var.autoscaling_target_cpu_load
+    condition = (
+      var.autoscaling_target_cpu_load == null
+      ? true
+      : local.alarm_cpu_threshold > var.autoscaling_target_cpu_load
+    )
     error_message = <<-EOF
       CPU alarm threshold (${local.alarm_cpu_threshold}%) must be greater than
       autoscaling target (${var.autoscaling_target_cpu_load}%).

--- a/deprecations.tf
+++ b/deprecations.tf
@@ -51,14 +51,14 @@ check "cpu_alarm_threshold_sane" {
     )
     error_message = <<-EOF
       CPU alarm threshold (${local.alarm_cpu_threshold}%) must be greater than
-      autoscaling target (${var.autoscaling_target_cpu_load}%).
+      autoscaling target (${local.cpu_tgt}%).
 
       The alarm should trigger AFTER autoscaling attempts to scale up.
       If alarm threshold <= autoscaling target, the alarm will fire immediately
       without giving autoscaling a chance to respond.
 
       Solution:
-        alarm_cpu_utilization_threshold = ${var.autoscaling_target_cpu_load + 30}
+        alarm_cpu_utilization_threshold = ${local.cpu_tgt_p30}
     EOF
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,8 @@ These variables must be provided:
 |----------|------|-------------|
 | `ami` | string | AMI ID for EC2 instances |
 | `backend_subnets` | list(string) | Subnet IDs where EC2 instances will run |
-| `internet_gateway_id` | string | Internet Gateway ID (ensures IGW exists) |
 | `key_pair_name` | string | SSH key pair name for EC2 instances |
+| `replication_region` | string | Region for cross-region replication of the access-log bucket |
 | `subnets` | list(string) | Subnet IDs where ALB will be deployed |
 | `userdata` | string | Cloud-init userdata for instance provisioning |
 | `zone_id` | string | Route53 hosted zone ID for DNS records |
@@ -39,7 +39,7 @@ module "website" {
 
   asg_min_size                = 2    # Minimum instances (default: 2)
   asg_max_size                = 10   # Maximum instances (default: 10)
-  autoscaling_target_cpu_load = 70   # Target CPU % (default: 60)
+  autoscaling_target_cpu_load = 70   # Target CPU % (default: 60; null to disable the policy)
 
   # Instance refresh settings
   min_healthy_percentage      = 100  # % healthy during refresh (default: 100)
@@ -51,6 +51,13 @@ module "website" {
   wait_for_capacity_timeout   = "15m"   # Timeout for healthy instances (default: 20m)
 }
 ```
+
+Set `autoscaling_target_cpu_load = null` to skip creating the host-CPU target-tracking
+policy entirely. Do this when instance count is driven by another controller — e.g. an
+ECS capacity provider's managed scaling — where a second ASG policy on the same
+`DesiredCapacity` lever would conflict. The high-CPU CloudWatch alarm is still created
+for Vanta compliance; when the target is `null` its threshold falls back to a fixed 90%
+(instead of target + 30%).
 
 ### Spot Instances
 
@@ -65,6 +72,56 @@ module "website" {
   # Additional capacity uses spot instances
 }
 ```
+
+### Capacity Reservations (ODCR)
+
+Bind the ASG's launch template to an On-Demand Capacity Reservation (ODCR) so
+instances launch into pre-reserved capacity. This guarantees a service can always
+get the instances it needs — useful for scarce instance types (e.g. GPU hosts like
+`g5.2xlarge`) where on-demand launches may otherwise fail with an
+`InsufficientInstanceCapacity` error.
+
+Target a single reservation by ID:
+
+```hcl
+module "website" {
+  # ... required variables ...
+
+  instance_type           = "g5.2xlarge"
+  capacity_reservation_id = "cr-0123456789abcdef0"
+
+  # Instances launch into this reservation (instance_match_criteria = targeted).
+}
+```
+
+Or target a group of reservations by resource-group ARN (lets you pool several
+reservations, e.g. across AZs, behind one identifier):
+
+```hcl
+module "website" {
+  # ... required variables ...
+
+  capacity_reservation_resource_group_arn =
+    "arn:aws:resource-groups:us-west-2:123456789012:group/my-odcr-group"
+}
+```
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `capacity_reservation_id` | string | `null` | Single ODCR to target |
+| `capacity_reservation_resource_group_arn` | string | `null` | Reservation resource-group ARN to target |
+
+**Notes:**
+
+- The two variables are **mutually exclusive** — set at most one. Setting both fails validation.
+- When neither is set (the default), the launch template has no capacity-reservation
+  block and behaves exactly as before, so existing deployments are unaffected.
+- Only the reservation *target* is set (not `capacity_reservation_preference`), so AWS
+  uses `instance_match_criteria = targeted`: only instances that explicitly target the
+  reservation consume it.
+- For an ECS-capacity-provider-managed ASG driving GPU capacity, pair this with
+  `autoscaling_target_cpu_load = null` (see [Auto Scaling](#auto-scaling)) so ECS
+  managed scaling is the sole controller of instance count.
 
 ### Lifecycle Hooks
 
@@ -122,7 +179,6 @@ module "website" {
 module "website" {
   # ... required variables ...
 
-  alb_healthcheck_enabled          = true        # Enable health checks (default: true)
   alb_healthcheck_path             = "/health"   # Health check path (default: /index.html)
   alb_healthcheck_port             = 8080        # Health check port (default: 80)
   alb_healthcheck_protocol         = "HTTP"      # HTTP or HTTPS (default: HTTP)
@@ -136,12 +192,16 @@ module "website" {
 
 ### Access Logging
 
+Access logging is always enabled (encrypted, versioned, cross-region-replicated bucket).
+Tune retention and teardown:
+
 ```hcl
 module "website" {
   # ... required variables ...
 
-  alb_access_log_enabled       = true   # Enable logging (default: false)
-  alb_access_log_force_destroy = false  # Delete bucket on destroy (default: false)
+  replication_region             = "us-east-1"  # Replica bucket region (required)
+  alb_access_log_expiration_days = 365           # Retention (default: 365)
+  alb_access_log_force_destroy   = false         # Delete bucket on destroy (default: false)
 }
 ```
 
@@ -151,7 +211,6 @@ module "website" {
 module "website" {
   # ... required variables ...
 
-  alb_access_log_enabled        = true   # Required
   alb_access_log_athena_enabled = true   # Creates Athena querying stack
 }
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -68,7 +68,6 @@ module "website" {
   alb_healthcheck_path  = "/health"
 
   # Security
-  alb_access_log_enabled = true
   enable_deletion_protection = true
 
   # Monitoring

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,8 +103,7 @@ module "website" {
   userdata            = module.userdata.userdata
 
   # Recommended settings
-  alarm_emails           = ["ops@example.com"]
-  alb_access_log_enabled = true
+  alarm_emails = ["ops@example.com"]
 }
 
 # Get the latest Ubuntu AMI

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,9 +45,6 @@ module "website" {
 
   # Enable monitoring (recommended)
   alarm_emails = ["ops@example.com"]
-
-  # Enable access logging (recommended for production)
-  alb_access_log_enabled = true
 }
 ```
 

--- a/locals.tf
+++ b/locals.tf
@@ -110,6 +110,14 @@ locals {
     99
   )
 
+  # Null-safe display strings for the cpu_alarm_threshold_sane check message.
+  # Terraform evaluates check error_messages eagerly, so the message must render even
+  # when autoscaling_target_cpu_load is null (the check is skipped for null, but the
+  # template is still evaluated). "n/a" never actually shows: the message only surfaces
+  # on assertion failure, which can only happen for a non-null target.
+  cpu_tgt     = var.autoscaling_target_cpu_load == null ? "n/a" : tostring(var.autoscaling_target_cpu_load)
+  cpu_tgt_p30 = var.autoscaling_target_cpu_load == null ? "n/a" : tostring(var.autoscaling_target_cpu_load + 30)
+
   # SNS topic ARNs to send alarms to
   alarm_sns_topics = concat(
     length(var.alarm_emails) > 0 ? [aws_sns_topic.alarms[0].arn] : [],

--- a/locals.tf
+++ b/locals.tf
@@ -96,13 +96,16 @@ locals {
     var.alb_idle_timeout * 0.8
   )
 
-  # Calculate CPU threshold: default to autoscaling target + 30%
+  # Calculate CPU threshold: default to autoscaling target + 30%.
+  # When autoscaling_target_cpu_load is null (host-CPU scaling policy disabled) there is
+  # no target to add a buffer to, so fall back to a fixed 90% — the CPU alarm stays for
+  # Vanta compliance ("Server CPU monitored") regardless of the scaling policy.
   # Cap at 99% instead of 100% because the alarm uses GreaterThanThreshold (>).
   # A threshold of 100 would mean "alert when CPU > 100%" which is impossible.
   alarm_cpu_threshold = min(
     coalesce(
       var.alarm_cpu_utilization_threshold,
-      var.autoscaling_target_cpu_load + 30
+      var.autoscaling_target_cpu_load != null ? var.autoscaling_target_cpu_load + 30 : 90
     ),
     99
   )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,12 @@ theme:
 
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - Architecture: architecture.md
+  - Examples: examples.md
+  - Troubleshooting: troubleshooting.md
+  - Changelog: changelog.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/moved.tf
+++ b/moved.tf
@@ -32,3 +32,11 @@ moved {
   from = aws_vpc_security_group_ingress_rule.https
   to   = aws_vpc_security_group_ingress_rule.https["0.0.0.0/0"]
 }
+
+# aws_autoscaling_policy.cpu_load gained a count when autoscaling_target_cpu_load
+# became nullable (null = don't create the policy). Preserve state for existing
+# consumers who keep a non-null target so the policy is not destroyed/recreated.
+moved {
+  from = aws_autoscaling_policy.cpu_load
+  to   = aws_autoscaling_policy.cpu_load[0]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,10 @@ variable "alb_healthcheck_port" {
 }
 
 variable "alb_healthcheck_protocol" {
-  description = "Protocol to use with the webserver that the elb will check to determine whether the instance is healthy or not"
+  description = <<-EOF
+    Protocol to use with the webserver that the elb will check to determine whether the
+    instance is healthy or not
+  EOF
   type        = string
   default     = "HTTP"
 
@@ -110,7 +113,10 @@ variable "alb_idle_timeout" {
 }
 
 variable "alb_listener_port" {
-  description = "TCP port that a load balancer listens to to serve client HTTP requests. The load balancer redirects this port to 443 and HTTPS."
+  description = <<-EOF
+    TCP port that a load balancer listens to to serve client HTTP requests. The load
+    balancer redirects this port to 443 and HTTPS.
+  EOF
   type        = number
   default     = 80
 }
@@ -144,7 +150,11 @@ variable "assume_dns" {
 }
 
 variable "min_healthy_percentage" {
-  description = "Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group."
+  description = <<-EOF
+    Amount of capacity in the Auto Scaling group that must remain healthy during an
+    instance refresh to allow the operation to continue, as a percentage of the desired
+    capacity of the Auto Scaling group.
+  EOF
   type        = number
   default     = 100
 }
@@ -192,14 +202,20 @@ variable "asg_lifecycle_hook_terminating_default_result" {
 }
 
 variable "asg_lifecycle_hook_heartbeat_timeout" {
-  description = "How much time in seconds to wait until the hook is completed before proceeding with the default action."
+  description = <<-EOF
+    How much time in seconds to wait until the hook is completed before proceeding with
+    the default action.
+  EOF
   type        = number
   default     = 3600
 }
 
 
 variable "asg_min_elb_capacity" {
-  description = "Terraform will wait until this many EC2 instances in the autoscaling group become healthy. By default, it's equal to var.asg_min_size."
+  description = <<-EOF
+    Terraform will wait until this many EC2 instances in the autoscaling group become
+    healthy. By default, it's equal to var.asg_min_size.
+  EOF
   type        = number
   default     = null
 }
@@ -216,13 +232,19 @@ variable "asg_max_size" {
   default     = 10
 }
 variable "asg_min_healthy_percentage" {
-  description = "Specifies the lower limit on the number of instances that must be in the InService state with a healthy status during an instance replacement activity."
+  description = <<-EOF
+    Specifies the lower limit on the number of instances that must be in the InService
+    state with a healthy status during an instance replacement activity.
+  EOF
   type        = number
   default     = 100
 }
 
 variable "asg_max_healthy_percentage" {
-  description = "Specifies the upper limit on the number of instances that are in the InService or Pending state with a healthy status during an instance replacement activity."
+  description = <<-EOF
+    Specifies the upper limit on the number of instances that are in the InService or
+    Pending state with a healthy status during an instance replacement activity.
+  EOF
   type        = number
   default     = 200
 
@@ -235,7 +257,10 @@ variable "asg_name" {
 }
 
 variable "asg_scale_in_protected_instances" {
-  description = "Behavior when encountering instances protected from scale in are found. Available behaviors are Refresh, Ignore, and Wait."
+  description = <<-EOF
+    Behavior when encountering instances protected from scale in are found. Available
+    behaviors are Refresh, Ignore, and Wait.
+  EOF
   type        = string
   default     = "Ignore"
 
@@ -298,9 +323,28 @@ variable "asg_enabled_metrics" {
 }
 
 variable "autoscaling_target_cpu_load" {
-  description = "Target CPU load for autoscaling"
+  description = <<-EOT
+    Target CPU load for the ASG host-CPU target-tracking policy (ASGAverageCPUUtilization).
+    Set to null to not create the policy at all. Do this when instance count is managed
+    elsewhere (e.g. an ECS capacity provider's managed scaling), where a second ASG policy
+    on the same DesiredCapacity lever conflicts. The high-CPU CloudWatch alarm is always
+    created for Vanta compliance; when this is null its threshold falls back to a fixed
+    90% instead of target + 30%.
+  EOT
   default     = 60
   type        = number
+
+  validation {
+    condition = (
+      var.autoscaling_target_cpu_load == null
+      ? true
+      : var.autoscaling_target_cpu_load > 0 && var.autoscaling_target_cpu_load <= 100
+    )
+    error_message = <<-EOT
+      autoscaling_target_cpu_load must be between 1 and 100, or null to disable the policy.
+      Got: ${var.autoscaling_target_cpu_load}
+    EOT
+  }
 }
 
 variable "backend_subnets" {
@@ -341,7 +385,10 @@ variable "extra_security_groups_backend" {
 }
 
 variable "instance_role_name" {
-  description = "If specified, the instance profile role will have this name. Otherwise, the role name will be generated."
+  description = <<-EOF
+    If specified, the instance profile role will have this name. Otherwise, the role name
+    will be generated.
+  EOF
   type        = string
   default     = null
 }
@@ -365,6 +412,33 @@ variable "instance_type" {
   description = "EC2 instances type"
   type        = string
   default     = "t3.micro"
+}
+
+variable "capacity_reservation_id" {
+  description = <<-EOT
+    Optional On-Demand Capacity Reservation ID to target from the launch template.
+    When set, instances launch into this reservation (instance_match_criteria = targeted).
+    Mutually exclusive with capacity_reservation_resource_group_arn.
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "capacity_reservation_resource_group_arn" {
+  description = <<-EOT
+    Optional Capacity Reservation resource-group ARN to target from the launch template
+    (an alternative to a single reservation ID).
+    Mutually exclusive with capacity_reservation_id.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition = !(
+      var.capacity_reservation_id != null && var.capacity_reservation_resource_group_arn != null
+    )
+    error_message = "Set only one of capacity_reservation_id or capacity_reservation_resource_group_arn, not both."
+  }
 }
 
 variable "health_check_grace_period" {
@@ -392,18 +466,27 @@ variable "key_pair_name" {
 }
 
 variable "max_instance_lifetime_days" {
-  description = "The maximum amount of time, in _days_, that an instance can be in service, values must be either equal to 0 or between 7 and 365 days."
+  description = <<-EOF
+    The maximum amount of time, in _days_, that an instance can be in service, values must
+    be either equal to 0 or between 7 and 365 days.
+  EOF
   type        = number
   default     = 30
 
   validation {
-    condition     = var.max_instance_lifetime_days == 0 || (var.max_instance_lifetime_days >= 7 && var.max_instance_lifetime_days <= 365)
+    condition = (
+      var.max_instance_lifetime_days == 0
+      || (var.max_instance_lifetime_days >= 7 && var.max_instance_lifetime_days <= 365)
+    )
     error_message = "max_instance_lifetime_days must be 0 (unlimited) or between 7 and 365 days."
   }
 }
 
 variable "protect_from_scale_in" {
-  description = "Whether newly launched instances are automatically protected from termination by Amazon EC2 Auto Scaling when scaling in."
+  description = <<-EOF
+    Whether newly launched instances are automatically protected from termination by
+    Amazon EC2 Auto Scaling when scaling in.
+  EOF
   type        = bool
   default     = false
 }
@@ -421,7 +504,10 @@ variable "service_name" {
 }
 
 variable "on_demand_base_capacity" {
-  description = "If specified, the ASG will request spot instances and this will be the minimal number of on-demand instances."
+  description = <<-EOF
+    If specified, the ASG will request spot instances and this will be the minimal number
+    of on-demand instances.
+  EOF
   type        = number
   default     = null
 }
@@ -538,7 +624,11 @@ variable "userdata" {
 }
 
 variable "vanta_owner" {
-  description = "The email address of the instance's owner, and it should be set to the email address of a user in Vanta. An owner will not be assigned if there is no user in Vanta with the email specified."
+  description = <<-EOF
+    The email address of the instance's owner, and it should be set to the email address
+    of a user in Vanta. An owner will not be assigned if there is no user in Vanta with
+    the email specified.
+  EOF
   type        = string
   default     = null
 }
@@ -553,19 +643,29 @@ variable "vanta_production_environments" {
 }
 
 variable "vanta_description" {
-  description = "This tag allows administrators to set a description, for instance, or add any other descriptive information."
+  description = <<-EOF
+    This tag allows administrators to set a description, for instance, or add any other
+    descriptive information.
+  EOF
   type        = string
   default     = null
 }
 
 variable "vanta_contains_user_data" {
-  description = "his tag allows administrators to define whether or not a resource contains user data (true) or if they do not contain user data (false)."
+  description = <<-EOF
+    This tag allows administrators to define whether or not a resource contains user data
+    (true) or if they do not contain user data (false).
+  EOF
   type        = bool
   default     = false
 }
 
 variable "vanta_contains_ephi" {
-  description = "This tag allows administrators to define whether or not a resource contains electronically Protected Health Information (ePHI). It can be set to either (true) or if they do not have ephi data (false)."
+  description = <<-EOF
+    This tag allows administrators to define whether or not a resource contains
+    electronically Protected Health Information (ePHI). It can be set to either (true) or
+    if they do not have ephi data (false).
+  EOF
   type        = bool
   default     = false
 }
@@ -577,7 +677,11 @@ variable "vanta_user_data_stored" {
 }
 
 variable "vanta_no_alert" {
-  description = "Administrators can add this tag to mark a resource as out of scope for their audit. If this tag is added, the administrator will need to set a reason for why it's not relevant to their audit."
+  description = <<-EOF
+    Administrators can add this tag to mark a resource as out of scope for their audit.
+    If this tag is added, the administrator will need to set a reason for why it's not
+    relevant to their audit.
+  EOF
   type        = string
   default     = null
 }
@@ -689,7 +793,10 @@ variable "dns_set_identifier" {
 }
 
 variable "certificate_issuers" {
-  description = "List of certificate authority domains allowed to issue certificates for this domain (e.g., [\"amazon.com\", \"letsencrypt.org\"]). The module will format these as CAA records."
+  description = <<-EOF
+    List of certificate authority domains allowed to issue certificates for this domain
+    (e.g., ["amazon.com", "letsencrypt.org"]). The module will format these as CAA records.
+  EOF
   type        = list(string)
   default     = ["amazon.com"]
 }
@@ -704,7 +811,10 @@ variable "allow_wildcard_certificates" {
 }
 
 variable "attach_target_group_to_asg" {
-  description = "Whether to register ASG instances in the target group. Disable if using ECS which registers targets itself."
+  description = <<-EOF
+    Whether to register ASG instances in the target group. Disable if using ECS which
+    registers targets itself.
+  EOF
   type        = bool
   default     = true
 }
@@ -807,7 +917,11 @@ variable "alarm_target_response_time_threshold" {
   default     = null
 
   validation {
-    condition     = var.alarm_target_response_time_threshold == null ? true : (var.alarm_target_response_time_threshold > 0 && var.alarm_target_response_time_threshold <= 3600)
+    condition = (
+      var.alarm_target_response_time_threshold == null
+      ? true
+      : var.alarm_target_response_time_threshold > 0 && var.alarm_target_response_time_threshold <= 3600
+    )
     error_message = <<-EOF
       Response time threshold must be between 0 and 3600 seconds (1 hour).
       Upper limit is generous to support edge cases like file uploads, batch processing,
@@ -913,7 +1027,11 @@ variable "alarm_cpu_utilization_threshold" {
   default     = null
 
   validation {
-    condition     = var.alarm_cpu_utilization_threshold == null ? true : (var.alarm_cpu_utilization_threshold > 0 && var.alarm_cpu_utilization_threshold < 100)
+    condition = (
+      var.alarm_cpu_utilization_threshold == null
+      ? true
+      : var.alarm_cpu_utilization_threshold > 0 && var.alarm_cpu_utilization_threshold < 100
+    )
     error_message = <<-EOF
       CPU utilization threshold must be between 0 and 99 (percentage).
       Threshold of 100 would never trigger since the alarm uses GreaterThanThreshold comparison.
@@ -975,8 +1093,15 @@ variable "warm_pool_state" {
   default     = null
 
   validation {
-    condition     = var.warm_pool_state == null ? true : contains(["Stopped", "Running", "Hibernated"], var.warm_pool_state)
-    error_message = "warm_pool_state must be null or one of Stopped, Running, Hibernated. Got: ${coalesce(var.warm_pool_state, "null")}"
+    condition = (
+      var.warm_pool_state == null
+      ? true
+      : contains(["Stopped", "Running", "Hibernated"], var.warm_pool_state)
+    )
+    error_message = <<-EOT
+      warm_pool_state must be null or one of Stopped, Running, Hibernated.
+      Got: ${coalesce(var.warm_pool_state, "null")}
+    EOT
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -342,7 +342,7 @@ variable "autoscaling_target_cpu_load" {
     )
     error_message = <<-EOT
       autoscaling_target_cpu_load must be between 1 and 100, or null to disable the policy.
-      Got: ${var.autoscaling_target_cpu_load}
+      Got: ${var.autoscaling_target_cpu_load == null ? "null" : tostring(var.autoscaling_target_cpu_load)}
     EOT
   }
 }


### PR DESCRIPTION
## Summary

Two opt-in ASG / launch-template changes that terraform-aws-ecs needs for GPU-utilization
autoscaling (vLLM on `g5.2xlarge`). Both default to today's behavior, so **existing consumers
see a byte-identical plan**. Implements `.claude/plans/gpu-ecs-support-odcr-and-cpu-policy-toggle.md`.

### 1. Launch-template capacity reservation (targeted ODCR)
- New `capacity_reservation_id` and `capacity_reservation_resource_group_arn` variables gate a
  `capacity_reservation_specification` block on the launch template.
- Only the reservation *target* is set (not `capacity_reservation_preference`), so AWS uses
  `instance_match_criteria = targeted`.
- The two variables are mutually exclusive (validated). Both `null` by default → block absent.

### 2. Optional host-CPU scaling policy
- `autoscaling_target_cpu_load` is now nullable. `null` skips `aws_autoscaling_policy.cpu_load`
  entirely — for ASGs whose instance count is driven by an ECS capacity provider's managed
  scaling, where a second policy on `DesiredCapacity` conflicts.
- `moved` block preserves state for consumers keeping a non-null target (no destroy/recreate).
- The high-CPU CloudWatch alarm stays for Vanta compliance; when the target is `null` its
  threshold falls back to a fixed 90% instead of target + 30%.
- Guarded the `cpu_alarm_threshold_sane` check block so the `null` path doesn't error at plan
  time on a number-vs-null comparison.

### Docs
- New Capacity Reservations (ODCR) and null-CPU-policy sections in `docs/configuration.md`.
- Added the missing pages to the mkdocs nav.
- Fixed stale references across README + docs: removed the no-longer-existent
  `internet_gateway_id`, `alb_access_log_enabled`, `alb_healthcheck_enabled`; added the now-required
  `replication_region`; clarified that access logging is unconditional; replaced the obsolete
  "removed in v6.0.0" deprecation section.
- Wrapped `variables.tf` long lines at 120; ignore the mkdocs `site/` build output.

## Testing
- `terraform fmt -check -recursive` clean.
- `terraform validate`: no new errors (only the module's pre-existing standalone `aws.dns`
  provider-alias errors, identical to `main`).
- `mkdocs build --strict` clean.
- Defaults unchanged → no-op plan for current consumers.

Follow-up: cut the minor release with `make release-minor` (→ 6.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)